### PR TITLE
fix: sync archive pagination state

### DIFF
--- a/packages/blog-starter-kit/themes/eplus/pages/archive.tsx
+++ b/packages/blog-starter-kit/themes/eplus/pages/archive.tsx
@@ -2,7 +2,7 @@ import { InferGetServerSidePropsType, GetServerSidePropsContext } from 'next';
 import { WithUrqlProps, initUrqlClient } from 'next-urql';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { NextIntlClientProvider, useTranslations } from 'next-intl';
 import { useEnvironmentTitle } from '../hooks/useEnvironmentTitle';
 
@@ -28,12 +28,20 @@ export default function Archive(
 	const { publication, posts, page, totalPages } = props;
 	const router = useRouter();
 	const t = useTranslations();
-	const [currentPage, setCurrentPage] = useState(page);
+        const [currentPage, setCurrentPage] = useState(page);
+
+        useEffect(() => {
+                setCurrentPage(page);
+        }, [page]);
 	const archiveTitle = useEnvironmentTitle(`${t('archive.title')} - ${publication.displayTitle || publication.title || 'Hashnode Blog'}`);
 
 	const handlePageChange = (newPage: number) => {
-		setCurrentPage(newPage);
-		router.push(`/archive?page=${newPage}`);
+                setCurrentPage(newPage);
+                router.push(
+                        { pathname: '/archive', query: { page: newPage } },
+                        undefined,
+                        { locale: router.locale },
+                );
 	};
 
 	const generatePaginationItems = () => {


### PR DESCRIPTION
### **User description**
## Summary
- keep archive page pagination state in sync with URL
- preserve locale when navigating between archive pages

## Testing
- `pnpm lint` *(fails: Do not use an `<a>` element to navigate to `/` in pages/404.tsx; Do not use an `<a>` element to navigate to `/login/` in components/reply-input.tsx)*
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68970d791244832bbfd417d2882543ae


___

### **PR Type**
Bug fix


___

### **Description**
- Sync archive pagination state with URL parameters

- Preserve locale when navigating between pages

- Fix pagination state management with useEffect


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["URL page param"] --> B["useEffect hook"]
  B --> C["currentPage state"]
  C --> D["handlePageChange"]
  D --> E["router.push with locale"]
  E --> A
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>archive.tsx</strong><dd><code>Fix pagination state sync and locale preservation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/blog-starter-kit/themes/eplus/pages/archive.tsx

<ul><li>Added useEffect import and hook to sync currentPage with URL<br> <li> Modified handlePageChange to use router.push with pathname/query <br>object<br> <li> Added locale preservation in navigation options<br> <li> Fixed indentation formatting</ul>


</details>


  </td>
  <td><a href="https://github.com/hoangsvit/hashnode-starter-kit/pull/20/files#diff-f2410b60a1c2ba4c095c8918ab4b8d8ee2d8f9edbd681479f83af7741f1a71cd">+12/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

