### PR TITLE
eplus: Add publication search page and fix header search imports

### DIFF
--- a/packages/blog-starter-kit/themes/eplus/components/header-blog-search.tsx
+++ b/packages/blog-starter-kit/themes/eplus/components/header-blog-search.tsx
@@ -1,41 +1,44 @@
 /* eslint-disable no-nested-ternary */
-import { useState, useRef } from 'react';
 import dynamic from 'next/dynamic';
+import { useRef, useState } from 'react';
 
-import CommonHeaderIconBtn from './common-header-icon-btn';
 import { PublicationFragment } from '../generated/graphql';
+import CommonHeaderIconBtn from './common-header-icon-btn';
 import SearchSVG from './icons/svgs/SearchSvg';
 
 const PublicationSearch = dynamic(() => import('./publication-search'), { ssr: false });
 
 interface Props {
-  publication: Pick<PublicationFragment, 'id' | 'title' | 'url' | 'isTeam' | 'favicon' | 'links' | 'author' | 'preferences'>
+	publication: Pick<
+		PublicationFragment,
+		'id' | 'title' | 'url' | 'isTeam' | 'favicon' | 'links' | 'author' | 'preferences'
+	>;
 }
 
 const HeaderBlogSearch = (props: Props) => {
-  const { publication } = props;
+	const { publication } = props;
 
-  const [isSearchUIVisible, toggleSearchUIState] = useState(false);
-  const triggerRef = useRef<HTMLButtonElement>(null);
+	const [isSearchUIVisible, toggleSearchUIState] = useState(false);
+	const triggerRef = useRef<HTMLButtonElement>(null);
 
-  const toggleSearchUI = () => {
-    toggleSearchUIState(!isSearchUIVisible);
-  };
+	const toggleSearchUI = () => {
+		toggleSearchUIState(!isSearchUIVisible);
+	};
 
-  return (
-    <>
-      {isSearchUIVisible ? (
-        <PublicationSearch publication={publication} toggleSearchUI={toggleSearchUI} triggerRef={triggerRef} />
-      ) : null}
-      <CommonHeaderIconBtn
-        handleClick={toggleSearchUI}
-        variant="search"
-        btnRef={triggerRef}
-      >
-        <SearchSVG className="h-6 w-6 stroke-current" />
-      </CommonHeaderIconBtn>
-    </>
-  );
+	return (
+		<>
+			{isSearchUIVisible ? (
+				<PublicationSearch
+					publication={publication}
+					toggleSearchUI={toggleSearchUI}
+					triggerRef={triggerRef}
+				/>
+			) : null}
+			<CommonHeaderIconBtn handleClick={toggleSearchUI} variant="search" btnRef={triggerRef}>
+				<SearchSVG className="h-6 w-6 stroke-current" />
+			</CommonHeaderIconBtn>
+		</>
+	);
 };
 
 export default HeaderBlogSearch;

--- a/packages/blog-starter-kit/themes/eplus/pages/search.tsx
+++ b/packages/blog-starter-kit/themes/eplus/pages/search.tsx
@@ -30,11 +30,12 @@ dayjs.extend(localizedFormat);
 
 const POSTS_PER_PAGE = 10;
 
+
 export default function SearchPage(props: InferGetServerSidePropsType<typeof getServerSideProps>) {
-	const { publication } = props;
+	const { publication, initialQuery = '' } = props;
 	const router = useRouter();
 	const t = useTranslations();
-	const [searchKey, setSearchKey] = useState('');
+	const [searchKey, setSearchKey] = useState(initialQuery);
 	const [after, setAfter] = useState<string | null>(null);
 
 	const normalizedSearchKey = searchKey.trim();
@@ -60,6 +61,10 @@ export default function SearchPage(props: InferGetServerSidePropsType<typeof get
 		if (!router.isReady) return;
 		const q = router.query.q;
 		const value = Array.isArray(q) ? q[0] : q || '';
+		// When the query param changes (e.g. navigation/back/forward),
+		// reset the pagination cursor so we don't continue from an
+		// old `after` value and accidentally skip initial results.
+		setAfter(null);
 		setSearchKey(value);
 	}, [router.isReady, router.query.q]);
 
@@ -204,7 +209,7 @@ export default function SearchPage(props: InferGetServerSidePropsType<typeof get
 													<>
 														<span className="mx-2 inline-block font-bold opacity-50">&middot;</span>
 														<p className="inline-block">
-															{post.reactionCount} {t('views')}
+															{post.reactionCount} {post.reactionCount === 1 ? t('views').slice(0, -1) : t('views')}
 														</p>
 													</>
 												)}
@@ -268,6 +273,10 @@ export default function SearchPage(props: InferGetServerSidePropsType<typeof get
 
 export const getServerSideProps = async (context: GetServerSidePropsContext) => {
 	const { locale = 'en' } = context;
+	// Extract `q` from the incoming request so the page can render
+	// correctly on the server with the initial search query.
+	const q = context.query.q;
+	const initialQuery = Array.isArray(q) ? q[0] : q || '';
 	const host = process.env.NEXT_PUBLIC_HASHNODE_PUBLICATION_HOST;
 	const messages = (await import(`../messages/${locale}.json`)).default;
 
@@ -284,8 +293,17 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
 			},
 		)
 		.toPromise();
-
+	if (publicationRes.error) {
+		console.error('Error while fetching publication', {
+			variables: { host },
+			error: publicationRes.error,
+		});
+		throw publicationRes.error;
+	}
 	if (!publicationRes.data?.publication) {
+		console.error('Publication not found fetching publication; returning 404', {
+			variables: { host },
+		});
 		return { notFound: true };
 	}
 
@@ -293,6 +311,7 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
 		props: {
 			messages,
 			publication: publicationRes.data.publication,
+			initialQuery,
 		},
 	};
 };

--- a/packages/blog-starter-kit/themes/eplus/pages/search.tsx
+++ b/packages/blog-starter-kit/themes/eplus/pages/search.tsx
@@ -1,0 +1,298 @@
+import dayjs from 'dayjs';
+import localizedFormat from 'dayjs/plugin/localizedFormat';
+import { GetServerSidePropsContext, InferGetServerSidePropsType } from 'next';
+import { useTranslations } from 'next-intl';
+import { initUrqlClient } from 'next-urql';
+import Head from 'next/head';
+import { useRouter } from 'next/router';
+import { useEffect, useMemo, useState } from 'react';
+import { twJoin, twMerge } from 'tailwind-merge';
+import { useQuery } from 'urql';
+
+import { AppProvider } from '../components/contexts/appContext';
+import CustomImage from '../components/custom-image';
+import { Header } from '../components/header';
+import Button from '../components/hn-button';
+import CloseSVG from '../components/icons/svgs/CloseSVG';
+import RefreshSVG from '../components/icons/svgs/RefreshSVG';
+import SearchSVG from '../components/icons/svgs/SearchSvg';
+import { Layout } from '../components/layout';
+import PublicationFooter from '../components/publication-footer';
+import { PublicationByHostDocument, SearchPostsOfPublicationDocument } from '../generated/graphql';
+import { useEnvironmentTitle } from '../hooks/useEnvironmentTitle';
+import { createHeaders, createSSRExchange, getUrqlClientConfig } from '../lib/api/client';
+import { blurImageDimensions } from '../utils/const/images';
+import { inputText } from '../utils/const/styles';
+import { getBlurHash, resizeImage } from '../utils/image';
+import { replaceLegacyPublicationUrl } from '../utils/urls';
+
+dayjs.extend(localizedFormat);
+
+const POSTS_PER_PAGE = 10;
+
+export default function SearchPage(props: InferGetServerSidePropsType<typeof getServerSideProps>) {
+	const { publication } = props;
+	const router = useRouter();
+	const t = useTranslations();
+	const [searchKey, setSearchKey] = useState('');
+	const [after, setAfter] = useState<string | null>(null);
+
+	const normalizedSearchKey = searchKey.trim();
+	const publicationTitle = publication.displayTitle || publication.title || 'Hashnode Blog';
+	const normalizedPublicationUrl = replaceLegacyPublicationUrl(publication.url || '').replace(
+		/\/$/,
+		'',
+	);
+	const searchPageUrl = `${normalizedPublicationUrl}/search`;
+
+	const searchTitle = useEnvironmentTitle(
+		normalizedSearchKey.length > 0
+			? `${t('search.results')}: ${normalizedSearchKey} - ${publicationTitle}`
+			: `${t('search.results')} - ${publicationTitle}`,
+	);
+
+	const searchDescription =
+		normalizedSearchKey.length > 0
+			? `${t('search.results')} for "${normalizedSearchKey}" on ${publicationTitle}`
+			: t('search.placeholder');
+
+	useEffect(() => {
+		if (!router.isReady) return;
+		const q = router.query.q;
+		const value = Array.isArray(q) ? q[0] : q || '';
+		setSearchKey(value);
+	}, [router.isReady, router.query.q]);
+
+	const [{ data, fetching }] = useQuery({
+		query: SearchPostsOfPublicationDocument,
+		variables: {
+			first: normalizedSearchKey.length > 0 ? POSTS_PER_PAGE : 0,
+			after,
+			filter: {
+				publicationId: publication.id,
+				query: searchKey,
+			},
+		},
+		pause: normalizedSearchKey.length === 0,
+	});
+
+	const results = data?.searchPostsOfPublication;
+
+	const handleKeywordChange = (value: string) => {
+		setAfter(null);
+		setSearchKey(value);
+
+		const nextQuery = value.trim();
+		router.replace(
+			{
+				pathname: '/search',
+				query: nextQuery ? { q: nextQuery } : {},
+			},
+			undefined,
+			{ shallow: true },
+		);
+	};
+
+	const clearResults = () => {
+		setAfter(null);
+		setSearchKey('');
+		router.replace('/search', undefined, { shallow: true });
+	};
+
+	const isInputEmpty = normalizedSearchKey.length === 0;
+	const hasResults = !!results?.edges?.length;
+	const isResultEmpty = !isInputEmpty && !hasResults && !fetching;
+
+	const loadMore = () => {
+		if (!results?.pageInfo?.hasNextPage || !results?.pageInfo?.endCursor) return;
+		setAfter(results.pageInfo.endCursor);
+	};
+
+	const renderedResults = useMemo(() => {
+		if (!results?.edges) return [];
+		return results.edges;
+	}, [results?.edges]);
+
+	return (
+		<AppProvider publication={publication}>
+			<Layout>
+				<Head>
+					<title>{searchTitle}</title>
+					<meta name="description" content={searchDescription} />
+					<meta name="robots" content="noindex,follow" />
+					<link rel="canonical" href={searchPageUrl} />
+					<meta property="og:title" content={searchTitle} />
+					<meta property="og:description" content={searchDescription} />
+					<meta property="og:url" content={searchPageUrl} />
+					<meta property="og:type" content="website" />
+					<meta property="twitter:title" content={searchTitle} />
+					<meta property="twitter:description" content={searchDescription} />
+				</Head>
+				<Header isHome={false} />
+				<main className="container mx-auto max-w-5xl px-4 py-8">
+					<h1 className="mb-6 text-3xl font-bold text-slate-900 dark:text-slate-100">
+						{t('search.results')}
+					</h1>
+					<div className="relative mb-8 w-full">
+						<input
+							value={searchKey}
+							onChange={(e) => handleKeywordChange(e.target.value)}
+							type="text"
+							className={twMerge(inputText, 'rounded-full px-6 py-3')}
+							placeholder={
+								fetching
+									? t('search.placeholder').replace('...', t('loading'))
+									: t('search.placeholder')
+							}
+						/>
+						{fetching ? (
+							<RefreshSVG className="animate-hn-spin absolute bottom-0 right-0 top-0 my-auto mr-16 h-5 w-5 fill-current text-slate-500 dark:text-slate-200" />
+						) : null}
+						{!isInputEmpty ? (
+							<button
+								aria-label={t('search.clearResults')}
+								type="button"
+								className="absolute bottom-1/2 right-4 top-1/2 flex h-8 w-8 -translate-y-1/2 items-center justify-center rounded-full hover:bg-slate-100 focus:bg-slate-100 focus:outline-none dark:hover:bg-slate-800 dark:focus:bg-slate-800"
+								onClick={clearResults}
+							>
+								<CloseSVG className="h-5 w-5 fill-current text-slate-500 dark:text-slate-200" />
+							</button>
+						) : null}
+					</div>
+
+					{isInputEmpty && (
+						<div className="my-6 flex items-center justify-center text-slate-500 dark:text-slate-300">
+							<SearchSVG className="mr-2.5 h-5 w-5 stroke-current" />
+							<p>{t('search.placeholder')}</p>
+						</div>
+					)}
+
+					{isResultEmpty && (
+						<div className="my-6 flex items-center justify-center text-slate-500 dark:text-slate-300">
+							<SearchSVG className="mr-2.5 h-5 w-5 stroke-current" />
+							<p>{t('search.noResults')}</p>
+						</div>
+					)}
+
+					<div className="space-y-4">
+						{renderedResults.map((item) => {
+							const post = item.node;
+							const postURL = replaceLegacyPublicationUrl(post.url) || post.url || '#';
+							const pubOrigin = replaceLegacyPublicationUrl(post.publication?.url || '')
+								.replace('https://', '')
+								.replace('http://', '');
+
+							return (
+								<a
+									key={post.id}
+									href={postURL}
+									className="block rounded-xl border border-slate-200 bg-white p-4 transition hover:bg-slate-50 dark:border-slate-800 dark:bg-slate-900 dark:hover:bg-slate-800/70"
+								>
+									<div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+										<div className="md:mr-4">
+											<h2 className="mb-2 text-2xl font-bold leading-snug tracking-tight text-slate-900 dark:text-slate-100">
+												{post.title}
+											</h2>
+											<div className="mb-3 flex flex-row flex-wrap items-center font-medium text-slate-500 dark:text-slate-400">
+												<p className="inline-block">{post?.author?.name || 'Anonymous'}</p>
+												<span className="mx-2 inline-block font-bold opacity-50">&middot;</span>
+												<p className="inline-block">{pubOrigin}</p>
+											</div>
+											<div className="flex flex-row items-center text-slate-500 dark:text-slate-400">
+												<p className="inline-block">{dayjs(post.publishedAt).format('LL')}</p>
+												{post.reactionCount > 0 && (
+													<>
+														<span className="mx-2 inline-block font-bold opacity-50">&middot;</span>
+														<p className="inline-block">
+															{post.reactionCount} {t('views')}
+														</p>
+													</>
+												)}
+											</div>
+										</div>
+
+										<div
+											className={twJoin(
+												'w-full shrink-0 overflow-hidden rounded-xl bg-slate-100 md:w-56 dark:bg-slate-900',
+												post.coverImage && post.coverImage.url.includes('cdn.hashnode.com')
+													? 'border dark:border-slate-800'
+													: '',
+											)}
+										>
+											{post.coverImage && post.coverImage.url.includes('cdn.hashnode.com') ? (
+												<CustomImage
+													originalSrc={post.coverImage.url}
+													src={resizeImage(post.coverImage.url, { w: 1600, h: 840, c: 'thumb' })}
+													width={800}
+													height={420}
+													layout="responsive"
+													objectFit="contain"
+													blurDataURL={getBlurHash(
+														resizeImage(post.coverImage.url, {
+															...blurImageDimensions,
+															c: 'thumb',
+														}),
+													)}
+													alt={post.title}
+												/>
+											) : null}
+										</div>
+									</div>
+								</a>
+							);
+						})}
+					</div>
+
+					{!fetching && results?.pageInfo?.hasNextPage ? (
+						<div className="mt-8 flex justify-center">
+							<Button variant="primary" onClick={loadMore}>
+								{t('archive.loadMorePosts')}
+							</Button>
+						</div>
+					) : null}
+				</main>
+				{publication && (
+					<PublicationFooter
+						authorName={publication.author.name}
+						title={publication.title}
+						imprint={publication.imprint}
+						disableFooterBranding={publication.preferences.disableFooterBranding}
+						isTeam={publication.isTeam}
+						logo={publication.preferences.logo}
+					/>
+				)}
+			</Layout>
+		</AppProvider>
+	);
+}
+
+export const getServerSideProps = async (context: GetServerSidePropsContext) => {
+	const { locale = 'en' } = context;
+	const host = process.env.NEXT_PUBLIC_HASHNODE_PUBLICATION_HOST;
+	const messages = (await import(`../messages/${locale}.json`)).default;
+
+	const ssrCache = createSSRExchange();
+	const urqlClient = initUrqlClient(getUrqlClientConfig(ssrCache), false);
+
+	const publicationRes = await urqlClient
+		.query(
+			PublicationByHostDocument,
+			{ host },
+			{
+				fetchOptions: { headers: createHeaders({ byPassCache: false }) },
+				requestPolicy: 'network-only',
+			},
+		)
+		.toPromise();
+
+	if (!publicationRes.data?.publication) {
+		return { notFound: true };
+	}
+
+	return {
+		props: {
+			messages,
+			publication: publicationRes.data.publication,
+		},
+	};
+};

--- a/packages/blog-starter-kit/themes/eplus/pages/search.tsx
+++ b/packages/blog-starter-kit/themes/eplus/pages/search.tsx
@@ -5,7 +5,7 @@ import { useTranslations } from 'next-intl';
 import { initUrqlClient } from 'next-urql';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { twJoin, twMerge } from 'tailwind-merge';
 import { useQuery } from 'urql';
 
@@ -36,7 +36,9 @@ export default function SearchPage(props: InferGetServerSidePropsType<typeof get
 	const router = useRouter();
 	const t = useTranslations();
 	const [searchKey, setSearchKey] = useState(initialQuery);
+	const [inputValue, setInputValue] = useState(initialQuery);
 	const [after, setAfter] = useState<string | null>(null);
+	const debounceRef = useRef<number | null>(null);
 
 	const normalizedSearchKey = searchKey.trim();
 	const publicationTitle = publication.displayTitle || publication.title || 'Hashnode Blog';
@@ -66,6 +68,12 @@ export default function SearchPage(props: InferGetServerSidePropsType<typeof get
 		// old `after` value and accidentally skip initial results.
 		setAfter(null);
 		setSearchKey(value);
+		setInputValue(value);
+		// clear any pending debounced update when navigation occurs
+		if (debounceRef.current) {
+			window.clearTimeout(debounceRef.current);
+			debounceRef.current = null;
+		}
 	}, [router.isReady, router.query.q]);
 
 	const [{ data, fetching }] = useQuery({
@@ -83,7 +91,7 @@ export default function SearchPage(props: InferGetServerSidePropsType<typeof get
 
 	const results = data?.searchPostsOfPublication;
 
-	const handleKeywordChange = (value: string) => {
+	const applySearch = (value: string) => {
 		setAfter(null);
 		setSearchKey(value);
 
@@ -98,9 +106,34 @@ export default function SearchPage(props: InferGetServerSidePropsType<typeof get
 		);
 	};
 
+	const handleKeywordChange = (value: string) => {
+		setInputValue(value);
+		if (debounceRef.current) {
+			window.clearTimeout(debounceRef.current);
+		}
+		// debounce applying the search to avoid frequent router.replace and queries
+		// (300ms matches `publication-search` behavior)
+		// store numeric id returned by setTimeout
+		debounceRef.current = window.setTimeout(() => {
+			applySearch(value);
+			debounceRef.current = null;
+		}, 300);
+	};
+
+	useEffect(() => {
+		return () => {
+			if (debounceRef.current) window.clearTimeout(debounceRef.current);
+		};
+	}, []);
+
 	const clearResults = () => {
 		setAfter(null);
 		setSearchKey('');
+		setInputValue('');
+		if (debounceRef.current) {
+			window.clearTimeout(debounceRef.current);
+			debounceRef.current = null;
+		}
 		router.replace('/search', undefined, { shallow: true });
 	};
 
@@ -140,7 +173,7 @@ export default function SearchPage(props: InferGetServerSidePropsType<typeof get
 					</h1>
 					<div className="relative mb-8 w-full">
 						<input
-							value={searchKey}
+							value={inputValue}
 							onChange={(e) => handleKeywordChange(e.target.value)}
 							type="text"
 							className={twMerge(inputText, 'rounded-full px-6 py-3')}


### PR DESCRIPTION
### Motivation

- Provide a dedicated `/search` page for publication-wide post search with server-side publication resolution and client-side result pagination. 
- Keep header search component clean and consistent by resolving import ordering and formatting.

### Description

- Add `pages/search.tsx` implementing a full search UI that fetches the publication via `getServerSideProps`, performs searches with the `SearchPostsOfPublicationDocument` GraphQL query using `urql`, supports pagination (`loadMore`), and renders results with `Layout`, `Header`, and `PublicationFooter` components. 
- Implement search state syncing with the URL query (`q`) and provide clear/refresh/empty-state UI, localized strings via `next-intl`, and image handling via `CustomImage`, `resizeImage`, and `getBlurHash`.  
- Wire canonical/meta tags for the search page and use `AppProvider` for publication context. 
- Tidy up `header-blog-search.tsx` imports and formatting by adjusting the `useRef`/`useState` import order and reorganizing import lines without functional changes.

### Testing

- No automated tests were executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b804e57264832892237b7e5f90ba83)