### PR TITLE
Fix ePlus navbar page links

### DIFF
--- a/packages/blog-starter-kit/themes/eplus/components/publication-nav-links-dropdown.tsx
+++ b/packages/blog-starter-kit/themes/eplus/components/publication-nav-links-dropdown.tsx
@@ -1,54 +1,56 @@
-import React from 'react';
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
+import Link from 'next/link';
+import React from 'react';
 
+import { twJoin } from 'tailwind-merge';
+import { getPublicationRelativeUrl } from '../utils/urls';
 import { CheckSVG } from './icons/svgs/';
 import CustomScrollArea from './scroll-area';
-import { twJoin } from 'tailwind-merge';
 
 type Props = {
-  extraNavbarItems: any;
+	extraNavbarItems: any;
 };
 
 function PublicationNavLinksDropdown(props: Props) {
-  const { extraNavbarItems } = props;
+	const { extraNavbarItems } = props;
 
-  return (
-    <DropdownMenu.Portal>
-      <DropdownMenu.Content
-        align="end"
-        className="z-50 mt-2 w-64 overflow-hidden whitespace-normal rounded-xl border bg-white py-2 capitalize text-slate-700 shadow-lg dark:border-slate-700 dark:bg-slate-800 dark:text-white"
-      >
-        <CustomScrollArea>
-          <div className="max-h-72">
-            {extraNavbarItems.length
-              ? extraNavbarItems.map((navItem: any, index: number) => (
-                  <React.Fragment key={`${navItem.label}-${index}`}>
-                    <DropdownMenu.DropdownMenuItem asChild>
-                      <a
-                        href={navItem.url}
-                        className={twJoin(
-                          navItem.isActive ? 'blog-nav-more-item-active' : 'blog-nav-more-item',
-                          'flex flex-row items-center justify-between px-4 py-3 font-medium hover:bg-slate-100 focus:bg-slate-100 focus:outline-none dark:hover:bg-slate-700 dark:focus:bg-slate-700',
-                          navItem.isActive && 'font-bold',
-                        )}
-                      >
-                        <span>{navItem.label}</span>
-                        {navItem.isActive ? (
-                          <CheckSVG className="h-5 w-5 fill-current text-blue-600 dark:text-white" />
-                        ) : null}
-                      </a>
-                    </DropdownMenu.DropdownMenuItem>
-                    {index !== extraNavbarItems.length - 1 ? (
-                      <hr className="h-px w-full border-none bg-slate-200 dark:bg-slate-700" />
-                    ) : null}
-                  </React.Fragment>
-                ))
-              : null}
-          </div>
-        </CustomScrollArea>
-      </DropdownMenu.Content>
-    </DropdownMenu.Portal>
-  );
+	return (
+		<DropdownMenu.Portal>
+			<DropdownMenu.Content
+				align="end"
+				className="z-50 mt-2 w-64 overflow-hidden whitespace-normal rounded-xl border bg-white py-2 capitalize text-slate-700 shadow-lg dark:border-slate-700 dark:bg-slate-800 dark:text-white"
+			>
+				<CustomScrollArea>
+					<div className="max-h-72">
+						{extraNavbarItems.length
+							? extraNavbarItems.map((navItem: any, index: number) => (
+									<React.Fragment key={`${navItem.label}-${index}`}>
+										<DropdownMenu.DropdownMenuItem asChild>
+											<Link
+												href={getPublicationRelativeUrl(navItem.url) || '#'}
+												className={twJoin(
+													navItem.isActive ? 'blog-nav-more-item-active' : 'blog-nav-more-item',
+													'flex flex-row items-center justify-between px-4 py-3 font-medium hover:bg-slate-100 focus:bg-slate-100 focus:outline-none dark:hover:bg-slate-700 dark:focus:bg-slate-700',
+													navItem.isActive && 'font-bold',
+												)}
+											>
+												<span>{navItem.label}</span>
+												{navItem.isActive ? (
+													<CheckSVG className="h-5 w-5 fill-current text-blue-600 dark:text-white" />
+												) : null}
+											</Link>
+										</DropdownMenu.DropdownMenuItem>
+										{index !== extraNavbarItems.length - 1 ? (
+											<hr className="h-px w-full border-none bg-slate-200 dark:bg-slate-700" />
+										) : null}
+									</React.Fragment>
+								))
+							: null}
+					</div>
+				</CustomScrollArea>
+			</DropdownMenu.Content>
+		</DropdownMenu.Portal>
+	);
 }
 
 export default PublicationNavLinksDropdown;

--- a/packages/blog-starter-kit/themes/eplus/components/publication-nav-links.tsx
+++ b/packages/blog-starter-kit/themes/eplus/components/publication-nav-links.tsx
@@ -1,128 +1,131 @@
 /* eslint-disable no-nested-ternary */
-import { useRef } from 'react';
+import * as DropdownPrimitive from '@radix-ui/react-dropdown-menu';
 import dynamic from 'next/dynamic';
 import Link from 'next/link';
+import { useRef } from 'react';
 import PerfectScrollbar from 'react-perfect-scrollbar';
-import * as DropdownPrimitive from '@radix-ui/react-dropdown-menu';
 import { twJoin } from 'tailwind-merge';
-import { ChevronDownV2SVG } from './icons/svgs';
 import { PublicationFragment } from '../generated/graphql';
 import { MAX_MAIN_NAV_LINKS } from '../utils/const';
+import { getPublicationRelativeUrl } from '../utils/urls';
+import { ChevronDownV2SVG } from './icons/svgs';
 
-const PublicationNavLinksDropdown = dynamic(
-  () => import('./publication-nav-links-dropdown'),
-  {
-    ssr: false,
-  },
-);
+const PublicationNavLinksDropdown = dynamic(() => import('./publication-nav-links-dropdown'), {
+	ssr: false,
+});
 
 type Props = {
-  currentActiveMenuItemId?: string | null;
-  isHome?: boolean | null;
+	currentActiveMenuItemId?: string | null;
+	isHome?: boolean | null;
 } & Pick<NonNullable<PublicationFragment['preferences']>, 'enabledPages' | 'navbarItems'>;
 
 function PublicationNavLinks(props: Props) {
-  const { currentActiveMenuItemId, isHome, enabledPages, navbarItems } = props;
+	const { currentActiveMenuItemId, isHome, enabledPages, navbarItems } = props;
 
-  const navItemsRef = useRef(
-    [
-      { label: 'home', url: '/', isActive: !currentActiveMenuItemId && isHome },
-      { label: 'archive', url: '/archive', isActive: currentActiveMenuItemId === 'archive' },
-      ...navbarItems.map((item) => {
-        const isCustomMenuItemActive = currentActiveMenuItemId && item.id === currentActiveMenuItemId;
-        return { ...item, isActive: isCustomMenuItemActive };
-      }),
-      enabledPages?.newsletter
-        ? { label: 'newsletter', url: '/newsletter', isActive: currentActiveMenuItemId === 'newsletter' }
-        : null
-    ].filter((item: any) => item),
-  );
+	const navItemsRef = useRef(
+		[
+			{ label: 'home', url: '/', isActive: !currentActiveMenuItemId && isHome },
+			{ label: 'archive', url: '/archive', isActive: currentActiveMenuItemId === 'archive' },
+			...navbarItems.map((item) => {
+				const isCustomMenuItemActive =
+					currentActiveMenuItemId && item.id === currentActiveMenuItemId;
+				return { ...item, isActive: isCustomMenuItemActive };
+			}),
+			enabledPages?.newsletter
+				? {
+						label: 'newsletter',
+						url: '/newsletter',
+						isActive: currentActiveMenuItemId === 'newsletter',
+					}
+				: null,
+		].filter((item: any) => item),
+	);
 
-  const extraNavItems = navItemsRef.current.slice(MAX_MAIN_NAV_LINKS);
-  const activeDropdownMenuItem = extraNavItems.find((item: any) => item?.isActive);
-  const isActiveItemInDropdown = !!activeDropdownMenuItem;
-  const showMoreDropdown = navItemsRef.current?.length - MAX_MAIN_NAV_LINKS > 1;
+	const extraNavItems = navItemsRef.current.slice(MAX_MAIN_NAV_LINKS);
+	const activeDropdownMenuItem = extraNavItems.find((item: any) => item?.isActive);
+	const isActiveItemInDropdown = !!activeDropdownMenuItem;
+	const showMoreDropdown = navItemsRef.current?.length - MAX_MAIN_NAV_LINKS > 1;
 
-  const numMainNavItemsToRender =
-    navItemsRef.current?.length - MAX_MAIN_NAV_LINKS === 1 ? MAX_MAIN_NAV_LINKS + 1 : MAX_MAIN_NAV_LINKS;
+	const numMainNavItemsToRender =
+		navItemsRef.current?.length - MAX_MAIN_NAV_LINKS === 1
+			? MAX_MAIN_NAV_LINKS + 1
+			: MAX_MAIN_NAV_LINKS;
 
-  const customNavbarItems =
-    navItemsRef.current && navItemsRef.current.length > 0
-      ? navItemsRef.current.slice(0, numMainNavItemsToRender).map((item: any) => {
-          if (!item.url) return null;
+	const customNavbarItems =
+		navItemsRef.current && navItemsRef.current.length > 0
+			? navItemsRef.current.slice(0, numMainNavItemsToRender).map((item: any) => {
+					if (!item.url) return null;
 
-          return (
-            <Link
-              className={twJoin(
-                item.isActive ? 'blog-nav-active' : 'blog-nav',
-                'group flex items-center justify-center border-b-2 border-transparent px-2 capitalize focus:outline-none',
-                item.isActive
-                  ? 'border-black dark:border-slate-50'
-                  : '',
-              )}
-              key={item.label}
-              href={item.url}
-            >
-              <span
-                className={twJoin(
-                  'blog-nav-text',
-                  'mb-2 block rounded-lg px-2 py-1 ring-offset-2 transition-colors duration-150 group-focus:ring',
-                'text-slate-900 hover:bg-slate-100 group-focus:ring-blue-600 group-focus:ring-offset-white dark:text-white dark:hover:bg-slate-800 dark:group-focus:ring-offset-slate-800',
-                  item.isActive
-                    ? 'font-semibold text-opacity-100 dark:text-opacity-100'
-                    : 'font-medium text-opacity-70 dark:text-opacity-70',
-                )}
-              >
-                {item.label}
-              </span>
-            </Link>
-          );
-        })
-      : null;
+					return (
+						<Link
+							className={twJoin(
+								item.isActive ? 'blog-nav-active' : 'blog-nav',
+								'group flex items-center justify-center border-b-2 border-transparent px-2 capitalize focus:outline-none',
+								item.isActive ? 'border-black dark:border-slate-50' : '',
+							)}
+							key={item.label}
+							href={getPublicationRelativeUrl(item.url) || '#'}
+						>
+							<span
+								className={twJoin(
+									'blog-nav-text',
+									'mb-2 block rounded-lg px-2 py-1 ring-offset-2 transition-colors duration-150 group-focus:ring',
+									'text-slate-900 hover:bg-slate-100 group-focus:ring-blue-600 group-focus:ring-offset-white dark:text-white dark:hover:bg-slate-800 dark:group-focus:ring-offset-slate-800',
+									item.isActive
+										? 'font-semibold text-opacity-100 dark:text-opacity-100'
+										: 'font-medium text-opacity-70 dark:text-opacity-70',
+								)}
+							>
+								{item.label}
+							</span>
+						</Link>
+					);
+				})
+			: null;
 
-  return (
-    <PerfectScrollbar className="overflow-hidden">
-      <nav className="relative flex flex-row flex-nowrap items-end whitespace-nowrap px-2 pt-2">
-        {customNavbarItems}
+	return (
+		<PerfectScrollbar className="overflow-hidden">
+			<nav className="relative flex flex-row flex-nowrap items-end whitespace-nowrap px-2 pt-2">
+				{customNavbarItems}
 
-        {showMoreDropdown ? (
-          <DropdownPrimitive.Root>
-            <DropdownPrimitive.Trigger asChild>
-              <button
-                aria-label="Toggle more links"
-                type="button"
-                className={twJoin(
-                  isActiveItemInDropdown ? 'blog-nav-active' : 'blog-nav',
-                  'group ml-2 border-b-2 border-transparent focus:outline-none active:outline-none',
-                  isActiveItemInDropdown
-                    ?'border-black dark:border-slate-50'
-                    : '',
-                )}
-              >
-                <div
-                  className={twJoin(
-                    'blog-nav-text',
-                    'mb-2 flex flex-row items-center rounded-lg px-2 py-1 ring-offset-2 transition-colors duration-150 group-focus:ring',
-                 'text-black hover:bg-slate-100 group-focus:ring-blue-600 group-focus:ring-offset-white dark:text-white dark:hover:bg-slate-800 dark:group-focus:ring-offset-slate-800',
-                    isActiveItemInDropdown
-                      ? 'font-semibold text-opacity-100 dark:text-opacity-100'
-                      : 'font-medium text-opacity-70 dark:text-opacity-70',
-                  )}
-                >
-                  <span className="capitalize">
-                    {isActiveItemInDropdown ? `${activeDropdownMenuItem?.label}` : 'More'}
-                  </span>
-                  <ChevronDownV2SVG className="ml-1 h-5 w-5 stroke-current" />
-                </div>
-              </button>
-            </DropdownPrimitive.Trigger>
-            {/* If there's only one extra nav item, render the extra one in main nav instead of using the dropdown */}
-            {showMoreDropdown ? <PublicationNavLinksDropdown extraNavbarItems={extraNavItems} /> : null}
-          </DropdownPrimitive.Root>
-        ) : null}
-      </nav>
-    </PerfectScrollbar>
-  );
+				{showMoreDropdown ? (
+					<DropdownPrimitive.Root>
+						<DropdownPrimitive.Trigger asChild>
+							<button
+								aria-label="Toggle more links"
+								type="button"
+								className={twJoin(
+									isActiveItemInDropdown ? 'blog-nav-active' : 'blog-nav',
+									'group ml-2 border-b-2 border-transparent focus:outline-none active:outline-none',
+									isActiveItemInDropdown ? 'border-black dark:border-slate-50' : '',
+								)}
+							>
+								<div
+									className={twJoin(
+										'blog-nav-text',
+										'mb-2 flex flex-row items-center rounded-lg px-2 py-1 ring-offset-2 transition-colors duration-150 group-focus:ring',
+										'text-black hover:bg-slate-100 group-focus:ring-blue-600 group-focus:ring-offset-white dark:text-white dark:hover:bg-slate-800 dark:group-focus:ring-offset-slate-800',
+										isActiveItemInDropdown
+											? 'font-semibold text-opacity-100 dark:text-opacity-100'
+											: 'font-medium text-opacity-70 dark:text-opacity-70',
+									)}
+								>
+									<span className="capitalize">
+										{isActiveItemInDropdown ? `${activeDropdownMenuItem?.label}` : 'More'}
+									</span>
+									<ChevronDownV2SVG className="ml-1 h-5 w-5 stroke-current" />
+								</div>
+							</button>
+						</DropdownPrimitive.Trigger>
+						{/* If there's only one extra nav item, render the extra one in main nav instead of using the dropdown */}
+						{showMoreDropdown ? (
+							<PublicationNavLinksDropdown extraNavbarItems={extraNavItems} />
+						) : null}
+					</DropdownPrimitive.Root>
+				) : null}
+			</nav>
+		</PerfectScrollbar>
+	);
 }
 
 export default PublicationNavLinks;

--- a/packages/blog-starter-kit/themes/eplus/components/publication-sidebar-nav-links.tsx
+++ b/packages/blog-starter-kit/themes/eplus/components/publication-sidebar-nav-links.tsx
@@ -1,84 +1,88 @@
 import Link from 'next/link';
-import { twJoin } from 'tailwind-merge';
 import { useRouter } from 'next/router';
+import { twJoin } from 'tailwind-merge';
 
-import { CheckSVG } from './icons/svgs';
 import { PublicationFragment } from '../generated/graphql';
-
+import { getPublicationRelativeUrl } from '../utils/urls';
+import { CheckSVG } from './icons/svgs';
 
 type IPublicationSidebarNavLinks = {
-  currentActiveMenuItemId?: string | null;
-  isHome?: boolean | null;
-  isBadge?: boolean | null;
+	currentActiveMenuItemId?: string | null;
+	isHome?: boolean | null;
+	isBadge?: boolean | null;
 } & Pick<NonNullable<PublicationFragment['preferences']>, 'enabledPages' | 'navbarItems'>;
 
 type IPublicationSidebarNavLinkItem = {
-  href: string;
-  label?: string | null;
-  isActive?: boolean;
+	href: string;
+	label?: string | null;
+	isActive?: boolean;
 };
 
 const PublicationSidebarNavLinkItem = ({
-  href,
-  label,
-  isActive,
+	href,
+	label,
+	isActive,
 }: IPublicationSidebarNavLinkItem) => {
-  const router = useRouter();
+	const router = useRouter();
 
-  // Handle i18n routing - for default locale (en), use path as-is
-  const localizedHref = router.locale === 'en' ? href : `/${router.locale}${href}`;
+	const normalizedHref = getPublicationRelativeUrl(href) || '#';
 
-  return (
-    <Link
-      href={localizedHref}
-      className={twJoin(
-        isActive ? 'blog-nav-active font-semibold' : 'blog-nav',
-        'focus-ring-base mb-1 flex w-full flex-row items-center justify-between rounded p-3 font-medium text-slate-700 transition-colors duration-100 hover:bg-slate-100 active:opacity-100 dark:text-slate-200 dark:hover:bg-slate-800',
-       'focus-ring-colors-base',
-      )}
-    >
-      <span>{label}</span>
-      {isActive ? <CheckSVG className="h-5 w-5 fill-current text-slate-600 dark:text-white" /> : null}
-    </Link>
-  );
+	// Handle i18n routing for internal paths only; keep external links untouched.
+	const localizedHref =
+		normalizedHref.startsWith('/') && router.locale !== 'en'
+			? `/${router.locale}${normalizedHref}`
+			: normalizedHref;
+
+	return (
+		<Link
+			href={localizedHref}
+			className={twJoin(
+				isActive ? 'blog-nav-active font-semibold' : 'blog-nav',
+				'focus-ring-base mb-1 flex w-full flex-row items-center justify-between rounded p-3 font-medium text-slate-700 transition-colors duration-100 hover:bg-slate-100 active:opacity-100 dark:text-slate-200 dark:hover:bg-slate-800',
+				'focus-ring-colors-base',
+			)}
+		>
+			<span>{label}</span>
+			{isActive ? (
+				<CheckSVG className="h-5 w-5 fill-current text-slate-600 dark:text-white" />
+			) : null}
+		</Link>
+	);
 };
 
 function PublicationSidebarNavLinks(props: IPublicationSidebarNavLinks) {
-  const { currentActiveMenuItemId, isHome, isBadge, enabledPages, navbarItems } = props;
-  const isHomePage = !currentActiveMenuItemId && isHome;
-  const isNewsletterPage = currentActiveMenuItemId && currentActiveMenuItemId === 'newsletter';
-  return (
-    <nav className="pb-8">
-      <PublicationSidebarNavLinkItem
-        href="/"
-        label="Home"
-        isActive={!!isHomePage}
-      />
+	const { currentActiveMenuItemId, isHome, isBadge, enabledPages, navbarItems } = props;
+	const isHomePage = !currentActiveMenuItemId && isHome;
+	const isNewsletterPage = currentActiveMenuItemId && currentActiveMenuItemId === 'newsletter';
+	return (
+		<nav className="pb-8">
+			<PublicationSidebarNavLinkItem href="/" label="Home" isActive={!!isHomePage} />
 
-      {navbarItems && navbarItems.length > 0
-        ? navbarItems.map((navItem) => {
-            if (!navItem.url) return null;
+			{navbarItems && navbarItems.length > 0
+				? navbarItems.map((navItem) => {
+						if (!navItem.url) return null;
 
-            const customTabIsActive = currentActiveMenuItemId && navItem.id === currentActiveMenuItemId;
-            return (
-              <PublicationSidebarNavLinkItem
-                key={navItem.id}
-                href={navItem.url}
-                label={navItem.label}
-                isActive={!!customTabIsActive}
-              />
-            );
-          })
-        : null}
-      {enabledPages?.newsletter ? (
-        <PublicationSidebarNavLinkItem
-          href="/newsletter"
-          label="Newsletter"
-          isActive={!!isNewsletterPage}
-        />
-      ) : null}
-    </nav>
-  );
+						const customTabIsActive =
+							currentActiveMenuItemId && navItem.id === currentActiveMenuItemId;
+						return (
+							<PublicationSidebarNavLinkItem
+								key={navItem.id}
+								href={navItem.url}
+								label={navItem.label}
+								isActive={!!customTabIsActive}
+							/>
+						);
+					})
+				: null}
+			{enabledPages?.newsletter ? (
+				<PublicationSidebarNavLinkItem
+					href="/newsletter"
+					label="Newsletter"
+					isActive={!!isNewsletterPage}
+				/>
+			) : null}
+		</nav>
+	);
 }
 
 export default PublicationSidebarNavLinks;

--- a/packages/blog-starter-kit/themes/eplus/utils/urls.ts
+++ b/packages/blog-starter-kit/themes/eplus/utils/urls.ts
@@ -101,24 +101,75 @@ export const createPostUrl = (
 
 export const createDraftPreviewUrl = (id: string) => `${getAppUrl()}/preview/${id}`;
 
+const LEGACY_HASHNODE_PUBLICATION_HOST = 'hoangit.hashnode.dev';
+const DEFAULT_FRONTEND_PUBLICATION_HOST = 'eplus.dev';
+
+const getFrontendPublicationHost = () =>
+	process.env.NEXT_PUBLIC_FRONTEND_PUBLICATION_HOST ||
+	process.env.NEXT_PUBLIC_SITE_HOST ||
+	DEFAULT_FRONTEND_PUBLICATION_HOST;
+
+const getFrontendPublicationOrigin = () => `https://${getFrontendPublicationHost()}`;
+
+const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const isHashnodePublicationHost = (hostname: string) => /(^|\.)hashnode\.dev$/i.test(hostname);
+
+const isFrontendPublicationHost = (hostname: string) =>
+	hostname.toLowerCase() === getFrontendPublicationHost().toLowerCase();
+
 export const replaceLegacyPublicationUrl = (url?: string | null) => {
 	if (!url) {
 		return url;
 	}
 
-	const customDomain = process.env.NEXT_PUBLIC_HASHNODE_PUBLICATION_HOST;
+	const frontendOrigin = getFrontendPublicationOrigin();
 
-	// Replace old hashnode subdomain (hoangit.hashnode.dev → eplus.dev)
-	let result = url.replace(/^https?:\/\/hoangit\.hashnode\.dev(?=\/|$)/i, 'https://eplus.dev');
+	// Replace the original Hashnode publication URL (hoangit.hashnode.dev) with
+	// the public frontend domain used by generated sitemaps and canonical URLs.
+	let result = url.replace(
+		new RegExp(
+			`^https?:\\/\\/${escapeRegExp(LEGACY_HASHNODE_PUBLICATION_HOST)}(?=\\/|$)`,
+			'i',
+		),
+		frontendOrigin,
+	);
 
-	// Replace any *.hashnode.dev subdomain when we have a custom domain configured
-	// e.g. eplus.hashnode.dev → eplus.dev
-	if (customDomain) {
-		result = result.replace(
-			/^https?:\/\/[a-z0-9-]+\.hashnode\.dev(?=\/|$)/i,
-			`https://${customDomain}`,
-		);
-	}
+	// Hashnode can return navbar/static-page URLs on any *.hashnode.dev host.
+	// Keep those links on the public frontend instead of sending readers back to Hashnode.
+	result = result.replace(/^https?:\/\/[a-z0-9-]+\.hashnode\.dev(?=\/|$)/i, frontendOrigin);
 
 	return result;
+};
+
+export const getPublicationRelativeUrl = (url?: string | null) => {
+	const normalizedUrl = replaceLegacyPublicationUrl(url);
+
+	if (!normalizedUrl) {
+		return normalizedUrl;
+	}
+
+	if (
+		normalizedUrl.startsWith('/') ||
+		normalizedUrl.startsWith('#') ||
+		/^(mailto|tel):/i.test(normalizedUrl)
+	) {
+		return normalizedUrl;
+	}
+
+	try {
+		const parsedUrl = new URL(normalizedUrl, getFrontendPublicationOrigin());
+
+		if (
+			isFrontendPublicationHost(parsedUrl.hostname) ||
+			parsedUrl.hostname.toLowerCase() === LEGACY_HASHNODE_PUBLICATION_HOST ||
+			isHashnodePublicationHost(parsedUrl.hostname)
+		) {
+			return `${parsedUrl.pathname}${parsedUrl.search}${parsedUrl.hash}`;
+		}
+	} catch (error) {
+		return normalizedUrl;
+	}
+
+	return normalizedUrl;
 };


### PR DESCRIPTION
### Motivation
- Menu links were redirecting users back to Hashnode hosts instead of staying on the eplus frontend; sitemaps and navbar/static page URLs need to use the public frontend domain.

### Description
- Add URL normalization utilities in `packages/.../utils/urls.ts`: introduce frontend host overrides, `replaceLegacyPublicationUrl()` improvements and a new `getPublicationRelativeUrl()` helper to convert Hashnode publication URLs into frontend-relative routes.
- Use `getPublicationRelativeUrl()` in the main navigation: `publication-nav-links.tsx` now routes `navbarItems` through Next.js `Link` with normalized hrefs.
- Replace anchor tags with `next/link` in the More dropdown: `publication-nav-links-dropdown.tsx` uses normalized `href`s to avoid navigating away from the frontend.
- Apply normalization and locale-safe prefixing in the sidebar links: `publication-sidebar-nav-links.tsx` converts publication URLs to relative routes and prefixes locale only for internal paths.

### Testing
- Ran type checking with `pnpm --filter @starter-kit/blog-hashnode typecheck` and it completed successfully (note: pnpm printed a Node engine warning due to local Node version).
- Ran `git diff --check` and code formatting with `prettier` to ensure no diff issues; checks passed.
- Ran lint with `pnpm --filter @starter-kit/blog-hashnode lint` which failed due to pre-existing unrelated lint errors in `pages/404.tsx` and `components/reply-input.tsx`, not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb6d7b6ca88328b457ec3c499edbfe)