### PR TITLE
Optimize eplus sitemap page loading

### DIFF
--- a/packages/blog-starter-kit/themes/eplus/messages/en.json
+++ b/packages/blog-starter-kit/themes/eplus/messages/en.json
@@ -127,6 +127,24 @@
 		"clearResults": "Clear search results",
 		"openSearchPage": "Open full search page"
 	},
+	"sitemap": {
+		"title": "Sitemap",
+		"metaDescription": "Browse {shown} of {total} articles published on {title}.",
+		"showing": "Showing {shown} of {total} articles published on <publication>{title}</publication>",
+		"searchLabel": "Search posts",
+		"searchPlaceholder": "Search all posts...",
+		"searchButton": "Search",
+		"xmlIndex": "XML Sitemap Index",
+		"postsXml": "Posts XML",
+		"tagsXml": "Tags XML",
+		"jumpToYear": "Jump to year",
+		"articleSingular": "article",
+		"articlePlural": "articles",
+		"loadMorePosts": "Load more posts",
+		"loadingPosts": "Loading posts...",
+		"loadMoreError": "Could not load more posts. Please try again.",
+		"noArticlesFound": "No articles found."
+	},
 	"tags": {
 		"title": "Tags",
 		"postsTagged": "Posts tagged with"

--- a/packages/blog-starter-kit/themes/eplus/messages/en.json
+++ b/packages/blog-starter-kit/themes/eplus/messages/en.json
@@ -133,6 +133,7 @@
 		"showing": "Showing {shown} of {total} articles published on <publication>{title}</publication>",
 		"searchLabel": "Search posts",
 		"searchPlaceholder": "Search all posts...",
+		"searching": "Searching...",
 		"searchButton": "Search",
 		"xmlIndex": "XML Sitemap Index",
 		"postsXml": "Posts XML",

--- a/packages/blog-starter-kit/themes/eplus/messages/es.json
+++ b/packages/blog-starter-kit/themes/eplus/messages/es.json
@@ -133,6 +133,7 @@
 		"showing": "Mostrando {shown} de {total} artículos publicados en <publication>{title}</publication>",
 		"searchLabel": "Buscar artículos",
 		"searchPlaceholder": "Buscar en todos los artículos...",
+		"searching": "Buscando...",
 		"searchButton": "Buscar",
 		"xmlIndex": "Índice XML del sitemap",
 		"postsXml": "XML de artículos",

--- a/packages/blog-starter-kit/themes/eplus/messages/es.json
+++ b/packages/blog-starter-kit/themes/eplus/messages/es.json
@@ -127,6 +127,24 @@
 		"clearResults": "Limpiar resultados de búsqueda",
 		"openSearchPage": "Abrir página de búsqueda completa"
 	},
+	"sitemap": {
+		"title": "Mapa del sitio",
+		"metaDescription": "Explora {shown} de {total} artículos publicados en {title}.",
+		"showing": "Mostrando {shown} de {total} artículos publicados en <publication>{title}</publication>",
+		"searchLabel": "Buscar artículos",
+		"searchPlaceholder": "Buscar en todos los artículos...",
+		"searchButton": "Buscar",
+		"xmlIndex": "Índice XML del sitemap",
+		"postsXml": "XML de artículos",
+		"tagsXml": "XML de etiquetas",
+		"jumpToYear": "Ir al año",
+		"articleSingular": "artículo",
+		"articlePlural": "artículos",
+		"loadMorePosts": "Cargar más artículos",
+		"loadingPosts": "Cargando artículos...",
+		"loadMoreError": "No se pudieron cargar más artículos. Inténtalo de nuevo.",
+		"noArticlesFound": "No se encontraron artículos."
+	},
 	"tags": {
 		"title": "Etiquetas",
 		"postsTagged": "Publicaciones etiquetadas con"

--- a/packages/blog-starter-kit/themes/eplus/messages/fr.json
+++ b/packages/blog-starter-kit/themes/eplus/messages/fr.json
@@ -127,6 +127,24 @@
 		"clearResults": "Effacer les résultats de recherche",
 		"openSearchPage": "Ouvrir la page de recherche complète"
 	},
+	"sitemap": {
+		"title": "Plan du site",
+		"metaDescription": "Parcourez {shown} des {total} articles publiés sur {title}.",
+		"showing": "Affichage de {shown} sur {total} articles publiés sur <publication>{title}</publication>",
+		"searchLabel": "Rechercher des articles",
+		"searchPlaceholder": "Rechercher dans tous les articles...",
+		"searchButton": "Rechercher",
+		"xmlIndex": "Index XML du sitemap",
+		"postsXml": "XML des articles",
+		"tagsXml": "XML des tags",
+		"jumpToYear": "Aller à l'année",
+		"articleSingular": "article",
+		"articlePlural": "articles",
+		"loadMorePosts": "Charger plus d'articles",
+		"loadingPosts": "Chargement des articles...",
+		"loadMoreError": "Impossible de charger plus d'articles. Veuillez réessayer.",
+		"noArticlesFound": "Aucun article trouvé."
+	},
 	"tags": {
 		"title": "Étiquettes",
 		"postsTagged": "Articles étiquetés avec"

--- a/packages/blog-starter-kit/themes/eplus/messages/fr.json
+++ b/packages/blog-starter-kit/themes/eplus/messages/fr.json
@@ -133,6 +133,7 @@
 		"showing": "Affichage de {shown} sur {total} articles publiés sur <publication>{title}</publication>",
 		"searchLabel": "Rechercher des articles",
 		"searchPlaceholder": "Rechercher dans tous les articles...",
+		"searching": "Recherche...",
 		"searchButton": "Rechercher",
 		"xmlIndex": "Index XML du sitemap",
 		"postsXml": "XML des articles",

--- a/packages/blog-starter-kit/themes/eplus/messages/hi.json
+++ b/packages/blog-starter-kit/themes/eplus/messages/hi.json
@@ -133,6 +133,7 @@
 		"showing": "<publication>{title}</publication> पर प्रकाशित कुल {total} लेखों में से {shown} दिखाए जा रहे हैं",
 		"searchLabel": "लेख खोजें",
 		"searchPlaceholder": "सभी लेखों में खोजें...",
+		"searching": "खोजा जा रहा है...",
 		"searchButton": "खोजें",
 		"xmlIndex": "XML साइटमैप इंडेक्स",
 		"postsXml": "लेख XML",

--- a/packages/blog-starter-kit/themes/eplus/messages/hi.json
+++ b/packages/blog-starter-kit/themes/eplus/messages/hi.json
@@ -127,6 +127,24 @@
 		"clearResults": "खोज परिणाम साफ़ करें",
 		"openSearchPage": "पूरा खोज पेज खोलें"
 	},
+	"sitemap": {
+		"title": "साइटमैप",
+		"metaDescription": "{title} पर प्रकाशित कुल {total} लेखों में से {shown} देखें।",
+		"showing": "<publication>{title}</publication> पर प्रकाशित कुल {total} लेखों में से {shown} दिखाए जा रहे हैं",
+		"searchLabel": "लेख खोजें",
+		"searchPlaceholder": "सभी लेखों में खोजें...",
+		"searchButton": "खोजें",
+		"xmlIndex": "XML साइटमैप इंडेक्स",
+		"postsXml": "लेख XML",
+		"tagsXml": "टैग XML",
+		"jumpToYear": "वर्ष पर जाएँ",
+		"articleSingular": "लेख",
+		"articlePlural": "लेख",
+		"loadMorePosts": "और लेख लोड करें",
+		"loadingPosts": "लेख लोड हो रहे हैं...",
+		"loadMoreError": "और लेख लोड नहीं हो सके। कृपया फिर से कोशिश करें।",
+		"noArticlesFound": "कोई लेख नहीं मिला।"
+	},
 	"tags": {
 		"title": "टैग",
 		"postsTagged": "टैग की गई पोस्ट"

--- a/packages/blog-starter-kit/themes/eplus/messages/ja.json
+++ b/packages/blog-starter-kit/themes/eplus/messages/ja.json
@@ -133,6 +133,7 @@
 		"showing": "<publication>{title}</publication>で公開された全{total}件の記事のうち{shown}件を表示しています",
 		"searchLabel": "記事を検索",
 		"searchPlaceholder": "すべての記事を検索...",
+		"searching": "検索中...",
 		"searchButton": "検索",
 		"xmlIndex": "XMLサイトマップインデックス",
 		"postsXml": "記事XML",

--- a/packages/blog-starter-kit/themes/eplus/messages/ja.json
+++ b/packages/blog-starter-kit/themes/eplus/messages/ja.json
@@ -127,6 +127,24 @@
 		"clearResults": "検索結果をクリア",
 		"openSearchPage": "検索ページを開く"
 	},
+	"sitemap": {
+		"title": "サイトマップ",
+		"metaDescription": "{title}で公開された全{total}件の記事のうち{shown}件を表示します。",
+		"showing": "<publication>{title}</publication>で公開された全{total}件の記事のうち{shown}件を表示しています",
+		"searchLabel": "記事を検索",
+		"searchPlaceholder": "すべての記事を検索...",
+		"searchButton": "検索",
+		"xmlIndex": "XMLサイトマップインデックス",
+		"postsXml": "記事XML",
+		"tagsXml": "タグXML",
+		"jumpToYear": "年へ移動",
+		"articleSingular": "記事",
+		"articlePlural": "記事",
+		"loadMorePosts": "さらに記事を読み込む",
+		"loadingPosts": "記事を読み込み中...",
+		"loadMoreError": "さらに記事を読み込めませんでした。もう一度お試しください。",
+		"noArticlesFound": "記事が見つかりませんでした。"
+	},
 	"tags": {
 		"title": "タグ",
 		"postsTagged": "タグ付けされた投稿"

--- a/packages/blog-starter-kit/themes/eplus/messages/vi.json
+++ b/packages/blog-starter-kit/themes/eplus/messages/vi.json
@@ -127,6 +127,24 @@
 		"clearResults": "Xóa kết quả tìm kiếm",
 		"openSearchPage": "Mở trang tìm kiếm đầy đủ"
 	},
+	"sitemap": {
+		"title": "Sơ đồ trang",
+		"metaDescription": "Duyệt {shown} trong tổng số {total} bài viết đã xuất bản trên {title}.",
+		"showing": "Đang hiển thị {shown} trong tổng số {total} bài viết đã xuất bản trên <publication>{title}</publication>",
+		"searchLabel": "Tìm bài viết",
+		"searchPlaceholder": "Tìm trong tất cả bài viết...",
+		"searchButton": "Tìm kiếm",
+		"xmlIndex": "Chỉ mục XML Sitemap",
+		"postsXml": "XML bài viết",
+		"tagsXml": "XML thẻ",
+		"jumpToYear": "Chuyển đến năm",
+		"articleSingular": "bài viết",
+		"articlePlural": "bài viết",
+		"loadMorePosts": "Tải thêm bài viết",
+		"loadingPosts": "Đang tải bài viết...",
+		"loadMoreError": "Không thể tải thêm bài viết. Vui lòng thử lại.",
+		"noArticlesFound": "Không tìm thấy bài viết nào."
+	},
 	"tags": {
 		"title": "Thẻ",
 		"postsTagged": "Bài viết được gắn thẻ"

--- a/packages/blog-starter-kit/themes/eplus/messages/vi.json
+++ b/packages/blog-starter-kit/themes/eplus/messages/vi.json
@@ -133,6 +133,7 @@
 		"showing": "Đang hiển thị {shown} trong tổng số {total} bài viết đã xuất bản trên <publication>{title}</publication>",
 		"searchLabel": "Tìm bài viết",
 		"searchPlaceholder": "Tìm trong tất cả bài viết...",
+		"searching": "Đang tìm kiếm...",
 		"searchButton": "Tìm kiếm",
 		"xmlIndex": "Chỉ mục XML Sitemap",
 		"postsXml": "XML bài viết",

--- a/packages/blog-starter-kit/themes/eplus/messages/zh.json
+++ b/packages/blog-starter-kit/themes/eplus/messages/zh.json
@@ -127,6 +127,24 @@
 		"clearResults": "清除搜索结果",
 		"openSearchPage": "打开完整搜索页面"
 	},
+	"sitemap": {
+		"title": "站点地图",
+		"metaDescription": "浏览 {title} 已发布的 {total} 篇文章中的 {shown} 篇。",
+		"showing": "正在显示 <publication>{title}</publication> 已发布的 {total} 篇文章中的 {shown} 篇",
+		"searchLabel": "搜索文章",
+		"searchPlaceholder": "搜索所有文章...",
+		"searchButton": "搜索",
+		"xmlIndex": "XML 站点地图索引",
+		"postsXml": "文章 XML",
+		"tagsXml": "标签 XML",
+		"jumpToYear": "跳转到年份",
+		"articleSingular": "篇文章",
+		"articlePlural": "篇文章",
+		"loadMorePosts": "加载更多文章",
+		"loadingPosts": "正在加载文章...",
+		"loadMoreError": "无法加载更多文章。请重试。",
+		"noArticlesFound": "未找到文章。"
+	},
 	"tags": {
 		"title": "标签",
 		"postsTagged": "标记为"

--- a/packages/blog-starter-kit/themes/eplus/messages/zh.json
+++ b/packages/blog-starter-kit/themes/eplus/messages/zh.json
@@ -133,6 +133,7 @@
 		"showing": "正在显示 <publication>{title}</publication> 已发布的 {total} 篇文章中的 {shown} 篇",
 		"searchLabel": "搜索文章",
 		"searchPlaceholder": "搜索所有文章...",
+		"searching": "正在搜索...",
 		"searchButton": "搜索",
 		"xmlIndex": "XML 站点地图索引",
 		"postsXml": "文章 XML",

--- a/packages/blog-starter-kit/themes/eplus/pages/sitemap.tsx
+++ b/packages/blog-starter-kit/themes/eplus/pages/sitemap.tsx
@@ -1,6 +1,6 @@
 import request from 'graphql-request';
 import { GetServerSidePropsContext, InferGetServerSidePropsType } from 'next';
-import { NextIntlClientProvider } from 'next-intl';
+import { NextIntlClientProvider, useTranslations } from 'next-intl';
 import Head from 'next/head';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
@@ -87,6 +87,7 @@ function SitemapPostsSkeleton() {
 
 function SitemapPage(props: InferGetServerSidePropsType<typeof getServerSideProps>) {
 	const router = useRouter();
+	const t = useTranslations();
 	const { publication, posts, totalPosts, initialPageInfo } = props;
 	const [sitemapPosts, setSitemapPosts] = useState(posts);
 	const [pageInfo, setPageInfo] = useState<SitemapPageInfo>(initialPageInfo);
@@ -133,7 +134,7 @@ function SitemapPage(props: InferGetServerSidePropsType<typeof getServerSideProp
 			setPageInfo(data.publication?.posts.pageInfo || { endCursor: null, hasNextPage: false });
 		} catch (error) {
 			console.error('Error while loading more sitemap posts', error);
-			setLoadMoreError('Could not load more posts. Please try again.');
+			setLoadMoreError(t('sitemap.loadMoreError'));
 		} finally {
 			setIsLoadingMore(false);
 		}
@@ -143,12 +144,16 @@ function SitemapPage(props: InferGetServerSidePropsType<typeof getServerSideProp
 		<AppProvider publication={publication}>
 			<Layout>
 				<Head>
-					<title>{`Sitemap — ${pubTitle}`}</title>
+					<title>{`${t('sitemap.title')} — ${pubTitle}`}</title>
 					<meta name="robots" content="index, follow" />
 					<link rel="canonical" href={`${publicationUrl}/sitemap`} />
 					<meta
 						name="description"
-						content={`Browse ${sitemapPosts.length} of ${totalPosts} articles published on ${pubTitle}.`}
+						content={t('sitemap.metaDescription', {
+							shown: sitemapPosts.length,
+							total: totalPosts,
+							title: pubTitle,
+						})}
 					/>
 				</Head>
 
@@ -158,37 +163,43 @@ function SitemapPage(props: InferGetServerSidePropsType<typeof getServerSideProp
 					{/* Page header */}
 					<div className="mb-10 border-b pb-8 dark:border-slate-800">
 						<h1 className="font-heading mb-3 text-3xl font-extrabold text-slate-900 md:text-4xl dark:text-white">
-							Sitemap
+							{t('sitemap.title')}
 						</h1>
 						<p className="text-slate-500 dark:text-slate-400">
-							Showing {sitemapPosts.length} of {totalPosts} articles published on{' '}
-							<Link
-								href="/"
-								className="font-medium text-blue-600 hover:underline dark:text-blue-400"
-							>
-								{pubTitle}
-							</Link>
+							{t.rich('sitemap.showing', {
+								shown: sitemapPosts.length,
+								total: totalPosts,
+								title: pubTitle,
+								publication: (chunks) => (
+									<Link
+										href="/"
+										className="font-medium text-blue-600 hover:underline dark:text-blue-400"
+									>
+										{chunks}
+									</Link>
+								),
+							})}
 						</p>
 						<form
 							onSubmit={submitSitemapSearch}
 							className="mt-6 flex flex-col gap-3 rounded-2xl border border-slate-200 bg-slate-50 p-3 sm:flex-row dark:border-slate-800 dark:bg-slate-900/60"
 						>
 							<label className="sr-only" htmlFor="sitemap-search">
-								Search posts
+								{t('sitemap.searchLabel')}
 							</label>
 							<input
 								id="sitemap-search"
 								type="search"
 								value={sitemapSearchQuery}
 								onChange={(event) => setSitemapSearchQuery(event.target.value)}
-								placeholder="Search all posts..."
+								placeholder={t('sitemap.searchPlaceholder')}
 								className="min-w-0 flex-1 rounded-full border border-slate-200 bg-white px-4 py-2.5 text-sm text-slate-800 outline-none transition placeholder:text-slate-400 focus:border-blue-400 focus:ring-2 focus:ring-blue-100 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:placeholder:text-slate-500 dark:focus:border-blue-500 dark:focus:ring-blue-950"
 							/>
 							<button
 								type="submit"
 								className="rounded-full bg-blue-600 px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-300 dark:bg-blue-500 dark:hover:bg-blue-400 dark:focus:ring-blue-800"
 							>
-								Search
+								{t('sitemap.searchButton')}
 							</button>
 						</form>
 
@@ -212,7 +223,7 @@ function SitemapPage(props: InferGetServerSidePropsType<typeof getServerSideProp
 										clipRule="evenodd"
 									/>
 								</svg>
-								XML Sitemap Index
+								{t('sitemap.xmlIndex')}
 							</a>
 							<a
 								href="/sitemap/posts.xml"
@@ -233,7 +244,7 @@ function SitemapPage(props: InferGetServerSidePropsType<typeof getServerSideProp
 									/>
 									<path d="M15 7h1a2 2 0 012 2v5.5a1.5 1.5 0 01-3 0V7z" />
 								</svg>
-								Posts XML
+								{t('sitemap.postsXml')}
 							</a>
 							<a
 								href="/sitemap/tags.xml"
@@ -253,13 +264,13 @@ function SitemapPage(props: InferGetServerSidePropsType<typeof getServerSideProp
 										clipRule="evenodd"
 									/>
 								</svg>
-								Tags XML
+								{t('sitemap.tagsXml')}
 							</a>
 						</div>
 					</div>
 					{/* Quick year nav */}
 					{years.length > 1 && (
-						<nav className="mb-8 flex flex-wrap gap-2" aria-label="Jump to year">
+						<nav className="mb-8 flex flex-wrap gap-2" aria-label={t('sitemap.jumpToYear')}>
 							{years.map((year) => (
 								<a
 									key={year}
@@ -285,7 +296,11 @@ function SitemapPage(props: InferGetServerSidePropsType<typeof getServerSideProp
 									</h2>
 									<span className="rounded-full bg-slate-100 px-2.5 py-0.5 text-xs font-semibold text-slate-500 dark:bg-slate-800 dark:text-slate-400">
 										{postsByYear[year].length}{' '}
-										{postsByYear[year].length === 1 ? 'article' : 'articles'}
+										{t(
+											postsByYear[year].length === 1
+												? 'sitemap.articleSingular'
+												: 'sitemap.articlePlural',
+										)}
 									</span>
 									<div className="h-px flex-1 bg-slate-100 dark:bg-slate-800" aria-hidden="true" />
 								</div>
@@ -334,14 +349,14 @@ function SitemapPage(props: InferGetServerSidePropsType<typeof getServerSideProp
 								disabled={isLoadingMore}
 								className="rounded-full bg-slate-900 px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-slate-700 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-white dark:text-slate-900 dark:hover:bg-slate-200"
 							>
-								{isLoadingMore ? 'Loading posts...' : 'Load more posts'}
+								{isLoadingMore ? t('sitemap.loadingPosts') : t('sitemap.loadMorePosts')}
 							</button>
 						</div>
 					)}
 
 					{sitemapPosts.length === 0 && (
 						<p className="py-16 text-center text-slate-500 dark:text-slate-400">
-							No articles found.
+							{t('sitemap.noArticlesFound')}
 						</p>
 					)}
 				</main>

--- a/packages/blog-starter-kit/themes/eplus/pages/sitemap.tsx
+++ b/packages/blog-starter-kit/themes/eplus/pages/sitemap.tsx
@@ -99,14 +99,16 @@ function SitemapPage(props: InferGetServerSidePropsType<typeof getServerSideProp
 	const publicationUrl = replaceLegacyPublicationUrl(publication.url) || publication.url;
 	const pubTitle = publication.displayTitle || publication.title;
 
+	const trimmedSearchQuery = sitemapSearchQuery.trim();
+	const isSearchDisabled = isSearching || trimmedSearchQuery.length === 0;
 	const postsByYear = useMemo(() => groupByYear(sitemapPosts), [sitemapPosts]);
 	const years = Object.keys(postsByYear).sort((a, b) => Number(b) - Number(a));
 
 	const submitSitemapSearch = async (event: FormEvent<HTMLFormElement>) => {
 		event.preventDefault();
-		if (isSearching) return;
+		if (isSearchDisabled) return;
 
-		const query = sitemapSearchQuery.trim();
+		const query = trimmedSearchQuery;
 		setIsSearching(true);
 
 		try {
@@ -204,11 +206,12 @@ function SitemapPage(props: InferGetServerSidePropsType<typeof getServerSideProp
 								onChange={(event) => setSitemapSearchQuery(event.target.value)}
 								placeholder={t('sitemap.searchPlaceholder')}
 								disabled={isSearching}
+								required
 								className="min-w-0 flex-1 rounded-full border border-slate-200 bg-white px-4 py-2.5 text-sm text-slate-800 outline-none transition placeholder:text-slate-400 focus:border-blue-400 focus:ring-2 focus:ring-blue-100 disabled:cursor-not-allowed disabled:opacity-70 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:placeholder:text-slate-500 dark:focus:border-blue-500 dark:focus:ring-blue-950"
 							/>
 							<button
 								type="submit"
-								disabled={isSearching}
+								disabled={isSearchDisabled}
 								className="inline-flex items-center justify-center gap-2 rounded-full bg-blue-600 px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-300 disabled:cursor-not-allowed disabled:opacity-70 dark:bg-blue-500 dark:hover:bg-blue-400 dark:focus:ring-blue-800"
 							>
 								{isSearching && (

--- a/packages/blog-starter-kit/themes/eplus/pages/sitemap.tsx
+++ b/packages/blog-starter-kit/themes/eplus/pages/sitemap.tsx
@@ -4,12 +4,16 @@ import { NextIntlClientProvider } from 'next-intl';
 import Head from 'next/head';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
+import { useMemo, useState } from 'react';
 
 import { AppProvider } from '../components/contexts/appContext';
 import { Header } from '../components/header';
 import { Layout } from '../components/layout';
 import PublicationFooter from '../components/publication-footer';
 import {
+	MorePostsByPublicationDocument,
+	MorePostsByPublicationQuery,
+	MorePostsByPublicationQueryVariables,
 	PostsByPublicationDocument,
 	PostsByPublicationQuery,
 	PostsByPublicationQueryVariables,
@@ -18,6 +22,7 @@ import { getTimezoneFromLocale } from '../utils/timezone';
 import { replaceLegacyPublicationUrl } from '../utils/urls';
 
 const GQL_ENDPOINT = process.env.NEXT_PUBLIC_HASHNODE_GQL_ENDPOINT;
+const HASHNODE_PUBLICATION_HOST = process.env.NEXT_PUBLIC_HASHNODE_PUBLICATION_HOST;
 const SITEMAP_POSTS_LIMIT = 50;
 
 type SitemapPost = {
@@ -26,6 +31,11 @@ type SitemapPost = {
 	slug: string;
 	url: string;
 	publishedAt: string;
+};
+
+type SitemapPageInfo = {
+	endCursor?: string | null;
+	hasNextPage?: boolean | null;
 };
 
 type PostsByYear = Record<string, SitemapPost[]>;
@@ -40,14 +50,82 @@ function groupByYear(posts: SitemapPost[]): PostsByYear {
 	return grouped;
 }
 
+function mapPostToSitemapPost(post: {
+	id: string;
+	title: string;
+	slug: string;
+	url: string;
+	publishedAt: string;
+}): SitemapPost {
+	return {
+		id: post.id,
+		title: post.title,
+		slug: post.slug,
+		url: replaceLegacyPublicationUrl(post.url) || post.url,
+		publishedAt: post.publishedAt,
+	};
+}
+
+function sortPostsNewestFirst(posts: SitemapPost[]): SitemapPost[] {
+	return [...posts].sort(
+		(a, b) => new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime(),
+	);
+}
+
+function SitemapPostsSkeleton() {
+	return (
+		<div className="space-y-3" aria-hidden="true">
+			{Array.from({ length: 5 }).map((_, index) => (
+				<div key={index} className="flex animate-pulse items-center gap-3 rounded-lg px-3 py-2.5">
+					<div className="h-3 w-16 shrink-0 rounded-full bg-slate-200 dark:bg-slate-800" />
+					<div className="h-4 flex-1 rounded-full bg-slate-200 dark:bg-slate-800" />
+				</div>
+			))}
+		</div>
+	);
+}
+
 function SitemapPage(props: InferGetServerSidePropsType<typeof getServerSideProps>) {
-	const { publication, posts, totalPosts } = props;
-	const hasMorePosts = totalPosts > posts.length;
+	const { publication, posts, totalPosts, initialPageInfo } = props;
+	const [sitemapPosts, setSitemapPosts] = useState(posts);
+	const [pageInfo, setPageInfo] = useState<SitemapPageInfo>(initialPageInfo);
+	const [isLoadingMore, setIsLoadingMore] = useState(false);
+	const [loadMoreError, setLoadMoreError] = useState<string | null>(null);
+	const hasMorePosts = Boolean(pageInfo.hasNextPage);
 	const publicationUrl = replaceLegacyPublicationUrl(publication.url) || publication.url;
 	const pubTitle = publication.displayTitle || publication.title;
 
-	const postsByYear = groupByYear(posts);
+	const postsByYear = useMemo(() => groupByYear(sitemapPosts), [sitemapPosts]);
 	const years = Object.keys(postsByYear).sort((a, b) => Number(b) - Number(a));
+
+	const loadMorePosts = async () => {
+		if (!hasMorePosts || isLoadingMore) return;
+
+		setIsLoadingMore(true);
+		setLoadMoreError(null);
+
+		try {
+			const data = await request<MorePostsByPublicationQuery, MorePostsByPublicationQueryVariables>(
+				GQL_ENDPOINT,
+				MorePostsByPublicationDocument,
+				{
+					host: HASHNODE_PUBLICATION_HOST,
+					first: SITEMAP_POSTS_LIMIT,
+					after: pageInfo.endCursor,
+				},
+			);
+
+			const nextPosts =
+				data.publication?.posts.edges.map((edge) => mapPostToSitemapPost(edge.node)) || [];
+			setSitemapPosts((currentPosts) => sortPostsNewestFirst([...currentPosts, ...nextPosts]));
+			setPageInfo(data.publication?.posts.pageInfo || { endCursor: null, hasNextPage: false });
+		} catch (error) {
+			console.error('Error while loading more sitemap posts', error);
+			setLoadMoreError('Could not load more posts. Please try again.');
+		} finally {
+			setIsLoadingMore(false);
+		}
+	};
 
 	return (
 		<AppProvider publication={publication}>
@@ -58,7 +136,7 @@ function SitemapPage(props: InferGetServerSidePropsType<typeof getServerSideProp
 					<link rel="canonical" href={`${publicationUrl}/sitemap`} />
 					<meta
 						name="description"
-						content={`Browse the latest ${posts.length} of ${totalPosts} articles published on ${pubTitle}.`}
+						content={`Browse ${sitemapPosts.length} of ${totalPosts} articles published on ${pubTitle}.`}
 					/>
 				</Head>
 
@@ -71,14 +149,13 @@ function SitemapPage(props: InferGetServerSidePropsType<typeof getServerSideProp
 							Sitemap
 						</h1>
 						<p className="text-slate-500 dark:text-slate-400">
-							Showing the latest {posts.length} of {totalPosts} articles published on{' '}
+							Showing {sitemapPosts.length} of {totalPosts} articles published on{' '}
 							<Link
 								href="/"
 								className="font-medium text-blue-600 hover:underline dark:text-blue-400"
 							>
 								{pubTitle}
 							</Link>
-							{hasMorePosts ? ' for faster page loading.' : '.'}
 						</p>
 						<div className="mt-4 flex flex-wrap gap-3 text-sm">
 							<a
@@ -145,14 +222,6 @@ function SitemapPage(props: InferGetServerSidePropsType<typeof getServerSideProp
 							</a>
 						</div>
 					</div>
-
-					{hasMorePosts && (
-						<div className="mb-8 rounded-2xl border border-blue-100 bg-blue-50 px-4 py-3 text-sm text-blue-800 dark:border-blue-900/60 dark:bg-blue-950/40 dark:text-blue-200">
-							This page loads only the newest {SITEMAP_POSTS_LIMIT} posts to stay fast. Use the XML
-							sitemaps above for the full search-engine sitemap.
-						</div>
-					)}
-
 					{/* Quick year nav */}
 					{years.length > 1 && (
 						<nav className="mb-8 flex flex-wrap gap-2" aria-label="Jump to year">
@@ -214,7 +283,28 @@ function SitemapPage(props: InferGetServerSidePropsType<typeof getServerSideProp
 						))}
 					</div>
 
-					{posts.length === 0 && (
+					{isLoadingMore && <SitemapPostsSkeleton />}
+
+					{loadMoreError && (
+						<p className="mt-6 text-center text-sm text-red-600 dark:text-red-400">
+							{loadMoreError}
+						</p>
+					)}
+
+					{hasMorePosts && (
+						<div className="mt-10 flex justify-center">
+							<button
+								type="button"
+								onClick={loadMorePosts}
+								disabled={isLoadingMore}
+								className="rounded-full bg-slate-900 px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-slate-700 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-white dark:text-slate-900 dark:hover:bg-slate-200"
+							>
+								{isLoadingMore ? 'Loading posts...' : 'Load more posts'}
+							</button>
+						</div>
+					)}
+
+					{sitemapPosts.length === 0 && (
 						<p className="py-16 text-center text-slate-500 dark:text-slate-400">
 							No articles found.
 						</p>
@@ -259,7 +349,7 @@ export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
 		GQL_ENDPOINT,
 		PostsByPublicationDocument,
 		{
-			host: process.env.NEXT_PUBLIC_HASHNODE_PUBLICATION_HOST,
+			host: HASHNODE_PUBLICATION_HOST,
 			first: SITEMAP_POSTS_LIMIT,
 		},
 	);
@@ -270,16 +360,9 @@ export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
 	}
 
 	// Load only the first page of posts so the HTML sitemap can render quickly.
-	const posts: SitemapPost[] = publication.posts.edges.map((edge) => ({
-		id: edge.node.id,
-		title: edge.node.title,
-		slug: edge.node.slug,
-		url: replaceLegacyPublicationUrl(edge.node.url) || edge.node.url,
-		publishedAt: edge.node.publishedAt,
-	}));
-
-	// Sort newest first
-	posts.sort((a, b) => new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime());
+	const posts = sortPostsNewestFirst(
+		publication.posts.edges.map((edge) => mapPostToSitemapPost(edge.node)),
+	);
 
 	return {
 		props: {
@@ -287,6 +370,7 @@ export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
 			publication,
 			posts,
 			totalPosts: publication.posts.totalDocuments || posts.length,
+			initialPageInfo: publication.posts.pageInfo,
 		},
 	};
 };

--- a/packages/blog-starter-kit/themes/eplus/pages/sitemap.tsx
+++ b/packages/blog-starter-kit/themes/eplus/pages/sitemap.tsx
@@ -94,6 +94,7 @@ function SitemapPage(props: InferGetServerSidePropsType<typeof getServerSideProp
 	const [isLoadingMore, setIsLoadingMore] = useState(false);
 	const [loadMoreError, setLoadMoreError] = useState<string | null>(null);
 	const [sitemapSearchQuery, setSitemapSearchQuery] = useState('');
+	const [isSearching, setIsSearching] = useState(false);
 	const hasMorePosts = Boolean(pageInfo.hasNextPage);
 	const publicationUrl = replaceLegacyPublicationUrl(publication.url) || publication.url;
 	const pubTitle = publication.displayTitle || publication.title;
@@ -101,14 +102,22 @@ function SitemapPage(props: InferGetServerSidePropsType<typeof getServerSideProp
 	const postsByYear = useMemo(() => groupByYear(sitemapPosts), [sitemapPosts]);
 	const years = Object.keys(postsByYear).sort((a, b) => Number(b) - Number(a));
 
-	const submitSitemapSearch = (event: FormEvent<HTMLFormElement>) => {
+	const submitSitemapSearch = async (event: FormEvent<HTMLFormElement>) => {
 		event.preventDefault();
+		if (isSearching) return;
 
 		const query = sitemapSearchQuery.trim();
-		router.push({
-			pathname: '/search',
-			query: query ? { q: query } : {},
-		});
+		setIsSearching(true);
+
+		try {
+			await router.push({
+				pathname: '/search',
+				query: query ? { q: query } : {},
+			});
+		} catch (error) {
+			console.error('Error while opening sitemap search', error);
+			setIsSearching(false);
+		}
 	};
 
 	const loadMorePosts = async () => {
@@ -182,6 +191,7 @@ function SitemapPage(props: InferGetServerSidePropsType<typeof getServerSideProp
 						</p>
 						<form
 							onSubmit={submitSitemapSearch}
+							aria-busy={isSearching}
 							className="mt-6 flex flex-col gap-3 rounded-2xl border border-slate-200 bg-slate-50 p-3 sm:flex-row dark:border-slate-800 dark:bg-slate-900/60"
 						>
 							<label className="sr-only" htmlFor="sitemap-search">
@@ -193,13 +203,21 @@ function SitemapPage(props: InferGetServerSidePropsType<typeof getServerSideProp
 								value={sitemapSearchQuery}
 								onChange={(event) => setSitemapSearchQuery(event.target.value)}
 								placeholder={t('sitemap.searchPlaceholder')}
-								className="min-w-0 flex-1 rounded-full border border-slate-200 bg-white px-4 py-2.5 text-sm text-slate-800 outline-none transition placeholder:text-slate-400 focus:border-blue-400 focus:ring-2 focus:ring-blue-100 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:placeholder:text-slate-500 dark:focus:border-blue-500 dark:focus:ring-blue-950"
+								disabled={isSearching}
+								className="min-w-0 flex-1 rounded-full border border-slate-200 bg-white px-4 py-2.5 text-sm text-slate-800 outline-none transition placeholder:text-slate-400 focus:border-blue-400 focus:ring-2 focus:ring-blue-100 disabled:cursor-not-allowed disabled:opacity-70 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:placeholder:text-slate-500 dark:focus:border-blue-500 dark:focus:ring-blue-950"
 							/>
 							<button
 								type="submit"
-								className="rounded-full bg-blue-600 px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-300 dark:bg-blue-500 dark:hover:bg-blue-400 dark:focus:ring-blue-800"
+								disabled={isSearching}
+								className="inline-flex items-center justify-center gap-2 rounded-full bg-blue-600 px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-300 disabled:cursor-not-allowed disabled:opacity-70 dark:bg-blue-500 dark:hover:bg-blue-400 dark:focus:ring-blue-800"
 							>
-								{t('sitemap.searchButton')}
+								{isSearching && (
+									<span
+										className="h-4 w-4 animate-spin rounded-full border-2 border-white/40 border-t-white"
+										aria-hidden="true"
+									/>
+								)}
+								{isSearching ? t('sitemap.searching') : t('sitemap.searchButton')}
 							</button>
 						</form>
 

--- a/packages/blog-starter-kit/themes/eplus/pages/sitemap.tsx
+++ b/packages/blog-starter-kit/themes/eplus/pages/sitemap.tsx
@@ -1,8 +1,8 @@
 import request from 'graphql-request';
 import { GetServerSidePropsContext, InferGetServerSidePropsType } from 'next';
+import { NextIntlClientProvider } from 'next-intl';
 import Head from 'next/head';
 import Link from 'next/link';
-import { NextIntlClientProvider } from 'next-intl';
 import { useRouter } from 'next/router';
 
 import { AppProvider } from '../components/contexts/appContext';
@@ -10,17 +10,15 @@ import { Header } from '../components/header';
 import { Layout } from '../components/layout';
 import PublicationFooter from '../components/publication-footer';
 import {
-	MorePostsByPublicationDocument,
-	MorePostsByPublicationQuery,
-	MorePostsByPublicationQueryVariables,
 	PostsByPublicationDocument,
 	PostsByPublicationQuery,
 	PostsByPublicationQueryVariables,
 } from '../generated/graphql';
-import { replaceLegacyPublicationUrl } from '../utils/urls';
 import { getTimezoneFromLocale } from '../utils/timezone';
+import { replaceLegacyPublicationUrl } from '../utils/urls';
 
 const GQL_ENDPOINT = process.env.NEXT_PUBLIC_HASHNODE_GQL_ENDPOINT;
+const SITEMAP_POSTS_LIMIT = 50;
 
 type SitemapPost = {
 	id: string;
@@ -44,6 +42,7 @@ function groupByYear(posts: SitemapPost[]): PostsByYear {
 
 function SitemapPage(props: InferGetServerSidePropsType<typeof getServerSideProps>) {
 	const { publication, posts, totalPosts } = props;
+	const hasMorePosts = totalPosts > posts.length;
 	const publicationUrl = replaceLegacyPublicationUrl(publication.url) || publication.url;
 	const pubTitle = publication.displayTitle || publication.title;
 
@@ -59,7 +58,7 @@ function SitemapPage(props: InferGetServerSidePropsType<typeof getServerSideProp
 					<link rel="canonical" href={`${publicationUrl}/sitemap`} />
 					<meta
 						name="description"
-						content={`Complete sitemap of all ${totalPosts} articles published on ${pubTitle}.`}
+						content={`Browse the latest ${posts.length} of ${totalPosts} articles published on ${pubTitle}.`}
 					/>
 				</Head>
 
@@ -68,14 +67,18 @@ function SitemapPage(props: InferGetServerSidePropsType<typeof getServerSideProp
 				<main className="container mx-auto max-w-5xl px-4 py-12 md:px-6">
 					{/* Page header */}
 					<div className="mb-10 border-b pb-8 dark:border-slate-800">
-						<h1 className="mb-3 font-heading text-3xl font-extrabold text-slate-900 dark:text-white md:text-4xl">
+						<h1 className="font-heading mb-3 text-3xl font-extrabold text-slate-900 md:text-4xl dark:text-white">
 							Sitemap
 						</h1>
 						<p className="text-slate-500 dark:text-slate-400">
-							{totalPosts} articles published on{' '}
-							<Link href="/" className="font-medium text-blue-600 hover:underline dark:text-blue-400">
+							Showing the latest {posts.length} of {totalPosts} articles published on{' '}
+							<Link
+								href="/"
+								className="font-medium text-blue-600 hover:underline dark:text-blue-400"
+							>
 								{pubTitle}
 							</Link>
+							{hasMorePosts ? ' for faster page loading.' : '.'}
 						</p>
 						<div className="mt-4 flex flex-wrap gap-3 text-sm">
 							<a
@@ -84,7 +87,12 @@ function SitemapPage(props: InferGetServerSidePropsType<typeof getServerSideProp
 								target="_blank"
 								rel="noopener noreferrer"
 							>
-								<svg className="h-3.5 w-3.5" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+								<svg
+									className="h-3.5 w-3.5"
+									fill="currentColor"
+									viewBox="0 0 20 20"
+									aria-hidden="true"
+								>
 									<path d="M10 12a2 2 0 100-4 2 2 0 000 4z" />
 									<path
 										fillRule="evenodd"
@@ -100,7 +108,12 @@ function SitemapPage(props: InferGetServerSidePropsType<typeof getServerSideProp
 								target="_blank"
 								rel="noopener noreferrer"
 							>
-								<svg className="h-3.5 w-3.5" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+								<svg
+									className="h-3.5 w-3.5"
+									fill="currentColor"
+									viewBox="0 0 20 20"
+									aria-hidden="true"
+								>
 									<path
 										fillRule="evenodd"
 										d="M2 5a2 2 0 012-2h8a2 2 0 012 2v10a2 2 0 002 2H4a2 2 0 01-2-2V5zm3 1h6v4H5V6zm6 6H5v2h6v-2z"
@@ -116,7 +129,12 @@ function SitemapPage(props: InferGetServerSidePropsType<typeof getServerSideProp
 								target="_blank"
 								rel="noopener noreferrer"
 							>
-								<svg className="h-3.5 w-3.5" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+								<svg
+									className="h-3.5 w-3.5"
+									fill="currentColor"
+									viewBox="0 0 20 20"
+									aria-hidden="true"
+								>
 									<path
 										fillRule="evenodd"
 										d="M17.707 9.293a1 1 0 010 1.414l-7 7a1 1 0 01-1.414 0l-7-7A.997.997 0 012 10V5a3 3 0 013-3h5c.256 0 .512.098.707.293l7 7zM5 6a1 1 0 100-2 1 1 0 000 2z"
@@ -127,6 +145,13 @@ function SitemapPage(props: InferGetServerSidePropsType<typeof getServerSideProp
 							</a>
 						</div>
 					</div>
+
+					{hasMorePosts && (
+						<div className="mb-8 rounded-2xl border border-blue-100 bg-blue-50 px-4 py-3 text-sm text-blue-800 dark:border-blue-900/60 dark:bg-blue-950/40 dark:text-blue-200">
+							This page loads only the newest {SITEMAP_POSTS_LIMIT} posts to stay fast. Use the XML
+							sitemaps above for the full search-engine sitemap.
+						</div>
+					)}
 
 					{/* Quick year nav */}
 					{years.length > 1 && (
@@ -209,7 +234,9 @@ function SitemapPage(props: InferGetServerSidePropsType<typeof getServerSideProp
 	);
 }
 
-export default function SitemapPageWrapper(props: InferGetServerSidePropsType<typeof getServerSideProps>) {
+export default function SitemapPageWrapper(
+	props: InferGetServerSidePropsType<typeof getServerSideProps>,
+) {
 	const router = useRouter();
 	return (
 		<NextIntlClientProvider
@@ -233,7 +260,7 @@ export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
 		PostsByPublicationDocument,
 		{
 			host: process.env.NEXT_PUBLIC_HASHNODE_PUBLICATION_HOST,
-			first: 50,
+			first: SITEMAP_POSTS_LIMIT,
 		},
 	);
 
@@ -242,7 +269,7 @@ export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
 		return { notFound: true };
 	}
 
-	// Collect all posts via pagination
+	// Load only the first page of posts so the HTML sitemap can render quickly.
 	const posts: SitemapPost[] = publication.posts.edges.map((edge) => ({
 		id: edge.node.id,
 		title: edge.node.title,
@@ -250,35 +277,6 @@ export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
 		url: replaceLegacyPublicationUrl(edge.node.url) || edge.node.url,
 		publishedAt: edge.node.publishedAt,
 	}));
-
-	const fetchMore = async (after: string | null | undefined): Promise<void> => {
-		const data = await request<MorePostsByPublicationQuery, MorePostsByPublicationQueryVariables>(
-			GQL_ENDPOINT,
-			MorePostsByPublicationDocument,
-			{
-				host: process.env.NEXT_PUBLIC_HASHNODE_PUBLICATION_HOST,
-				first: 50,
-				after,
-			},
-		);
-		if (!data.publication) return;
-		for (const edge of data.publication.posts.edges) {
-			posts.push({
-				id: edge.node.id,
-				title: edge.node.title,
-				slug: edge.node.slug,
-				url: replaceLegacyPublicationUrl(edge.node.url) || edge.node.url,
-				publishedAt: edge.node.publishedAt,
-			});
-		}
-		if (data.publication.posts.pageInfo.hasNextPage) {
-			await fetchMore(data.publication.posts.pageInfo.endCursor);
-		}
-	};
-
-	if (publication.posts.pageInfo.hasNextPage) {
-		await fetchMore(publication.posts.pageInfo.endCursor);
-	}
 
 	// Sort newest first
 	posts.sort((a, b) => new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime());
@@ -288,7 +286,7 @@ export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
 			messages,
 			publication,
 			posts,
-			totalPosts: posts.length,
+			totalPosts: publication.posts.totalDocuments || posts.length,
 		},
 	};
 };

--- a/packages/blog-starter-kit/themes/eplus/pages/sitemap.tsx
+++ b/packages/blog-starter-kit/themes/eplus/pages/sitemap.tsx
@@ -4,7 +4,7 @@ import { NextIntlClientProvider } from 'next-intl';
 import Head from 'next/head';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import { useMemo, useState } from 'react';
+import { FormEvent, useMemo, useState } from 'react';
 
 import { AppProvider } from '../components/contexts/appContext';
 import { Header } from '../components/header';
@@ -86,17 +86,29 @@ function SitemapPostsSkeleton() {
 }
 
 function SitemapPage(props: InferGetServerSidePropsType<typeof getServerSideProps>) {
+	const router = useRouter();
 	const { publication, posts, totalPosts, initialPageInfo } = props;
 	const [sitemapPosts, setSitemapPosts] = useState(posts);
 	const [pageInfo, setPageInfo] = useState<SitemapPageInfo>(initialPageInfo);
 	const [isLoadingMore, setIsLoadingMore] = useState(false);
 	const [loadMoreError, setLoadMoreError] = useState<string | null>(null);
+	const [sitemapSearchQuery, setSitemapSearchQuery] = useState('');
 	const hasMorePosts = Boolean(pageInfo.hasNextPage);
 	const publicationUrl = replaceLegacyPublicationUrl(publication.url) || publication.url;
 	const pubTitle = publication.displayTitle || publication.title;
 
 	const postsByYear = useMemo(() => groupByYear(sitemapPosts), [sitemapPosts]);
 	const years = Object.keys(postsByYear).sort((a, b) => Number(b) - Number(a));
+
+	const submitSitemapSearch = (event: FormEvent<HTMLFormElement>) => {
+		event.preventDefault();
+
+		const query = sitemapSearchQuery.trim();
+		router.push({
+			pathname: '/search',
+			query: query ? { q: query } : {},
+		});
+	};
 
 	const loadMorePosts = async () => {
 		if (!hasMorePosts || isLoadingMore) return;
@@ -157,6 +169,29 @@ function SitemapPage(props: InferGetServerSidePropsType<typeof getServerSideProp
 								{pubTitle}
 							</Link>
 						</p>
+						<form
+							onSubmit={submitSitemapSearch}
+							className="mt-6 flex flex-col gap-3 rounded-2xl border border-slate-200 bg-slate-50 p-3 sm:flex-row dark:border-slate-800 dark:bg-slate-900/60"
+						>
+							<label className="sr-only" htmlFor="sitemap-search">
+								Search posts
+							</label>
+							<input
+								id="sitemap-search"
+								type="search"
+								value={sitemapSearchQuery}
+								onChange={(event) => setSitemapSearchQuery(event.target.value)}
+								placeholder="Search all posts..."
+								className="min-w-0 flex-1 rounded-full border border-slate-200 bg-white px-4 py-2.5 text-sm text-slate-800 outline-none transition placeholder:text-slate-400 focus:border-blue-400 focus:ring-2 focus:ring-blue-100 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:placeholder:text-slate-500 dark:focus:border-blue-500 dark:focus:ring-blue-950"
+							/>
+							<button
+								type="submit"
+								className="rounded-full bg-blue-600 px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-300 dark:bg-blue-500 dark:hover:bg-blue-400 dark:focus:ring-blue-800"
+							>
+								Search
+							</button>
+						</form>
+
 						<div className="mt-4 flex flex-wrap gap-3 text-sm">
 							<a
 								href="/sitemap/index.xml"


### PR DESCRIPTION
### Motivation
- The HTML `/sitemap` page currently blocks SSR while recursively fetching every post page, causing slow load times; the intent is to render the page quickly while still exposing full sitemaps for search engines.

### Description
- Limit the HTML sitemap SSR query to the first page by introducing `SITEMAP_POSTS_LIMIT = 50` and only mapping `publication.posts.edges` from the initial response (file: `packages/blog-starter-kit/themes/eplus/pages/sitemap.tsx`).
- Remove the recursive pagination/fetch-more logic and the `MorePostsByPublication*` usage so the server no longer waits for all pages to load.
- Keep the total posts count sourced from `publication.posts.totalDocuments` so the UI can show the real total while only rendering the latest posts.
- Update meta description and on-page copy/banner to explain the HTML sitemap shows the newest posts for faster loading and direct users/search engines to the XML sitemaps for the full list.

### Testing
- Ran code formatting: `pnpm exec prettier --write packages/blog-starter-kit/themes/eplus/pages/sitemap.tsx` (succeeded).
- Ran type check: `pnpm --filter @starter-kit/blog-hashnode typecheck` (succeeded).
- Ran file-level lint: `pnpm exec next lint --file pages/sitemap.tsx` (succeeded with no ESLint warnings/errors for the changed file).
- Ran workspace lint: `pnpm --filter @starter-kit/blog-hashnode lint` (failed due to pre-existing/unrelated lint errors in other files such as `pages/404.tsx` and `components/reply-input.tsx`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe84781d288328bb0731c7a6be6d9d)