### PR TITLE
Enhance sitemap page with i18n, client search, incremental loading and translations

### DIFF
--- a/packages/blog-starter-kit/themes/eplus/messages/en.json
+++ b/packages/blog-starter-kit/themes/eplus/messages/en.json
@@ -127,6 +127,25 @@
 		"clearResults": "Clear search results",
 		"openSearchPage": "Open full search page"
 	},
+	"sitemap": {
+		"title": "Sitemap",
+		"metaDescription": "Browse {shown} of {total} articles published on {title}.",
+		"showing": "Showing {shown} of {total} articles published on <publication>{title}</publication>",
+		"searchLabel": "Search posts",
+		"searchPlaceholder": "Search all posts...",
+		"searching": "Searching...",
+		"searchButton": "Search",
+		"xmlIndex": "XML Sitemap Index",
+		"postsXml": "Posts XML",
+		"tagsXml": "Tags XML",
+		"jumpToYear": "Jump to year",
+		"articleSingular": "article",
+		"articlePlural": "articles",
+		"loadMorePosts": "Load more posts",
+		"loadingPosts": "Loading posts...",
+		"loadMoreError": "Could not load more posts. Please try again.",
+		"noArticlesFound": "No articles found."
+	},
 	"tags": {
 		"title": "Tags",
 		"postsTagged": "Posts tagged with"

--- a/packages/blog-starter-kit/themes/eplus/messages/es.json
+++ b/packages/blog-starter-kit/themes/eplus/messages/es.json
@@ -127,6 +127,25 @@
 		"clearResults": "Limpiar resultados de búsqueda",
 		"openSearchPage": "Abrir página de búsqueda completa"
 	},
+	"sitemap": {
+		"title": "Mapa del sitio",
+		"metaDescription": "Explora {shown} de {total} artículos publicados en {title}.",
+		"showing": "Mostrando {shown} de {total} artículos publicados en <publication>{title}</publication>",
+		"searchLabel": "Buscar artículos",
+		"searchPlaceholder": "Buscar en todos los artículos...",
+		"searching": "Buscando...",
+		"searchButton": "Buscar",
+		"xmlIndex": "Índice XML del sitemap",
+		"postsXml": "XML de artículos",
+		"tagsXml": "XML de etiquetas",
+		"jumpToYear": "Ir al año",
+		"articleSingular": "artículo",
+		"articlePlural": "artículos",
+		"loadMorePosts": "Cargar más artículos",
+		"loadingPosts": "Cargando artículos...",
+		"loadMoreError": "No se pudieron cargar más artículos. Inténtalo de nuevo.",
+		"noArticlesFound": "No se encontraron artículos."
+	},
 	"tags": {
 		"title": "Etiquetas",
 		"postsTagged": "Publicaciones etiquetadas con"

--- a/packages/blog-starter-kit/themes/eplus/messages/fr.json
+++ b/packages/blog-starter-kit/themes/eplus/messages/fr.json
@@ -127,6 +127,25 @@
 		"clearResults": "Effacer les résultats de recherche",
 		"openSearchPage": "Ouvrir la page de recherche complète"
 	},
+	"sitemap": {
+		"title": "Plan du site",
+		"metaDescription": "Parcourez {shown} des {total} articles publiés sur {title}.",
+		"showing": "Affichage de {shown} sur {total} articles publiés sur <publication>{title}</publication>",
+		"searchLabel": "Rechercher des articles",
+		"searchPlaceholder": "Rechercher dans tous les articles...",
+		"searching": "Recherche...",
+		"searchButton": "Rechercher",
+		"xmlIndex": "Index XML du sitemap",
+		"postsXml": "XML des articles",
+		"tagsXml": "XML des tags",
+		"jumpToYear": "Aller à l'année",
+		"articleSingular": "article",
+		"articlePlural": "articles",
+		"loadMorePosts": "Charger plus d'articles",
+		"loadingPosts": "Chargement des articles...",
+		"loadMoreError": "Impossible de charger plus d'articles. Veuillez réessayer.",
+		"noArticlesFound": "Aucun article trouvé."
+	},
 	"tags": {
 		"title": "Étiquettes",
 		"postsTagged": "Articles étiquetés avec"

--- a/packages/blog-starter-kit/themes/eplus/messages/hi.json
+++ b/packages/blog-starter-kit/themes/eplus/messages/hi.json
@@ -127,6 +127,25 @@
 		"clearResults": "खोज परिणाम साफ़ करें",
 		"openSearchPage": "पूरा खोज पेज खोलें"
 	},
+	"sitemap": {
+		"title": "साइटमैप",
+		"metaDescription": "{title} पर प्रकाशित कुल {total} लेखों में से {shown} देखें।",
+		"showing": "<publication>{title}</publication> पर प्रकाशित कुल {total} लेखों में से {shown} दिखाए जा रहे हैं",
+		"searchLabel": "लेख खोजें",
+		"searchPlaceholder": "सभी लेखों में खोजें...",
+		"searching": "खोजा जा रहा है...",
+		"searchButton": "खोजें",
+		"xmlIndex": "XML साइटमैप इंडेक्स",
+		"postsXml": "लेख XML",
+		"tagsXml": "टैग XML",
+		"jumpToYear": "वर्ष पर जाएँ",
+		"articleSingular": "लेख",
+		"articlePlural": "लेख",
+		"loadMorePosts": "और लेख लोड करें",
+		"loadingPosts": "लेख लोड हो रहे हैं...",
+		"loadMoreError": "और लेख लोड नहीं हो सके। कृपया फिर से कोशिश करें।",
+		"noArticlesFound": "कोई लेख नहीं मिला।"
+	},
 	"tags": {
 		"title": "टैग",
 		"postsTagged": "टैग की गई पोस्ट"

--- a/packages/blog-starter-kit/themes/eplus/messages/ja.json
+++ b/packages/blog-starter-kit/themes/eplus/messages/ja.json
@@ -127,6 +127,25 @@
 		"clearResults": "検索結果をクリア",
 		"openSearchPage": "検索ページを開く"
 	},
+	"sitemap": {
+		"title": "サイトマップ",
+		"metaDescription": "{title}で公開された全{total}件の記事のうち{shown}件を表示します。",
+		"showing": "<publication>{title}</publication>で公開された全{total}件の記事のうち{shown}件を表示しています",
+		"searchLabel": "記事を検索",
+		"searchPlaceholder": "すべての記事を検索...",
+		"searching": "検索中...",
+		"searchButton": "検索",
+		"xmlIndex": "XMLサイトマップインデックス",
+		"postsXml": "記事XML",
+		"tagsXml": "タグXML",
+		"jumpToYear": "年へ移動",
+		"articleSingular": "記事",
+		"articlePlural": "記事",
+		"loadMorePosts": "さらに記事を読み込む",
+		"loadingPosts": "記事を読み込み中...",
+		"loadMoreError": "さらに記事を読み込めませんでした。もう一度お試しください。",
+		"noArticlesFound": "記事が見つかりませんでした。"
+	},
 	"tags": {
 		"title": "タグ",
 		"postsTagged": "タグ付けされた投稿"

--- a/packages/blog-starter-kit/themes/eplus/messages/vi.json
+++ b/packages/blog-starter-kit/themes/eplus/messages/vi.json
@@ -127,6 +127,25 @@
 		"clearResults": "Xóa kết quả tìm kiếm",
 		"openSearchPage": "Mở trang tìm kiếm đầy đủ"
 	},
+	"sitemap": {
+		"title": "Sơ đồ trang",
+		"metaDescription": "Duyệt {shown} trong tổng số {total} bài viết đã xuất bản trên {title}.",
+		"showing": "Đang hiển thị {shown} trong tổng số {total} bài viết đã xuất bản trên <publication>{title}</publication>",
+		"searchLabel": "Tìm bài viết",
+		"searchPlaceholder": "Tìm trong tất cả bài viết...",
+		"searching": "Đang tìm kiếm...",
+		"searchButton": "Tìm kiếm",
+		"xmlIndex": "Chỉ mục XML Sitemap",
+		"postsXml": "XML bài viết",
+		"tagsXml": "XML thẻ",
+		"jumpToYear": "Chuyển đến năm",
+		"articleSingular": "bài viết",
+		"articlePlural": "bài viết",
+		"loadMorePosts": "Tải thêm bài viết",
+		"loadingPosts": "Đang tải bài viết...",
+		"loadMoreError": "Không thể tải thêm bài viết. Vui lòng thử lại.",
+		"noArticlesFound": "Không tìm thấy bài viết nào."
+	},
 	"tags": {
 		"title": "Thẻ",
 		"postsTagged": "Bài viết được gắn thẻ"

--- a/packages/blog-starter-kit/themes/eplus/messages/zh.json
+++ b/packages/blog-starter-kit/themes/eplus/messages/zh.json
@@ -127,6 +127,25 @@
 		"clearResults": "清除搜索结果",
 		"openSearchPage": "打开完整搜索页面"
 	},
+	"sitemap": {
+		"title": "站点地图",
+		"metaDescription": "浏览 {title} 已发布的 {total} 篇文章中的 {shown} 篇。",
+		"showing": "正在显示 <publication>{title}</publication> 已发布的 {total} 篇文章中的 {shown} 篇",
+		"searchLabel": "搜索文章",
+		"searchPlaceholder": "搜索所有文章...",
+		"searching": "正在搜索...",
+		"searchButton": "搜索",
+		"xmlIndex": "XML 站点地图索引",
+		"postsXml": "文章 XML",
+		"tagsXml": "标签 XML",
+		"jumpToYear": "跳转到年份",
+		"articleSingular": "篇文章",
+		"articlePlural": "篇文章",
+		"loadMorePosts": "加载更多文章",
+		"loadingPosts": "正在加载文章...",
+		"loadMoreError": "无法加载更多文章。请重试。",
+		"noArticlesFound": "未找到文章。"
+	},
 	"tags": {
 		"title": "标签",
 		"postsTagged": "标记为"

--- a/packages/blog-starter-kit/themes/eplus/pages/sitemap.tsx
+++ b/packages/blog-starter-kit/themes/eplus/pages/sitemap.tsx
@@ -66,10 +66,54 @@ function mapPostToSitemapPost(post: {
 	};
 }
 
+function getPostPublishedAtTimestamp(post: SitemapPost): number {
+	return new Date(post.publishedAt).getTime();
+}
+
 function sortPostsNewestFirst(posts: SitemapPost[]): SitemapPost[] {
-	return [...posts].sort(
-		(a, b) => new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime(),
-	);
+	return [...posts].sort((a, b) => getPostPublishedAtTimestamp(b) - getPostPublishedAtTimestamp(a));
+}
+
+function mergePostsNewestFirst(
+	currentPosts: SitemapPost[],
+	nextPosts: SitemapPost[],
+): SitemapPost[] {
+	const sortedNextPosts = sortPostsNewestFirst(nextPosts);
+	const mergedPosts: SitemapPost[] = [];
+	const seenPostIds = new Set<string>();
+	let currentIndex = 0;
+	let nextIndex = 0;
+
+	const appendPost = (post: SitemapPost) => {
+		if (seenPostIds.has(post.id)) return;
+		seenPostIds.add(post.id);
+		mergedPosts.push(post);
+	};
+
+	while (currentIndex < currentPosts.length && nextIndex < sortedNextPosts.length) {
+		const currentPost = currentPosts[currentIndex];
+		const nextPost = sortedNextPosts[nextIndex];
+
+		if (getPostPublishedAtTimestamp(currentPost) >= getPostPublishedAtTimestamp(nextPost)) {
+			appendPost(currentPost);
+			currentIndex += 1;
+		} else {
+			appendPost(nextPost);
+			nextIndex += 1;
+		}
+	}
+
+	while (currentIndex < currentPosts.length) {
+		appendPost(currentPosts[currentIndex]);
+		currentIndex += 1;
+	}
+
+	while (nextIndex < sortedNextPosts.length) {
+		appendPost(sortedNextPosts[nextIndex]);
+		nextIndex += 1;
+	}
+
+	return mergedPosts;
 }
 
 function SitemapPostsSkeleton() {
@@ -149,7 +193,7 @@ function SitemapPage(props: InferGetServerSidePropsType<typeof getServerSideProp
 
 			const nextPosts =
 				data.publication?.posts.edges.map((edge) => mapPostToSitemapPost(edge.node)) || [];
-			setSitemapPosts((currentPosts) => sortPostsNewestFirst([...currentPosts, ...nextPosts]));
+			setSitemapPosts((currentPosts) => mergePostsNewestFirst(currentPosts, nextPosts));
 			setPageInfo(data.publication?.posts.pageInfo || { endCursor: null, hasNextPage: false });
 		} catch (error) {
 			console.error('Error while loading more sitemap posts', error);

--- a/packages/blog-starter-kit/themes/eplus/pages/sitemap.tsx
+++ b/packages/blog-starter-kit/themes/eplus/pages/sitemap.tsx
@@ -191,10 +191,14 @@ function SitemapPage(props: InferGetServerSidePropsType<typeof getServerSideProp
 				},
 			);
 
-			const nextPosts =
-				data.publication?.posts.edges.map((edge) => mapPostToSitemapPost(edge.node)) || [];
+			const nextPostsConnection = data.publication?.posts;
+			if (!nextPostsConnection?.pageInfo) {
+				throw new Error('Missing publication posts while loading more sitemap posts');
+			}
+
+			const nextPosts = nextPostsConnection.edges.map((edge) => mapPostToSitemapPost(edge.node));
 			setSitemapPosts((currentPosts) => mergePostsNewestFirst(currentPosts, nextPosts));
-			setPageInfo(data.publication?.posts.pageInfo || { endCursor: null, hasNextPage: false });
+			setPageInfo(nextPostsConnection.pageInfo);
 		} catch (error) {
 			console.error('Error while loading more sitemap posts', error);
 			setLoadMoreError(t('sitemap.loadMoreError'));

--- a/packages/blog-starter-kit/themes/eplus/pages/sitemap.tsx
+++ b/packages/blog-starter-kit/themes/eplus/pages/sitemap.tsx
@@ -155,12 +155,14 @@ function SitemapPage(props: InferGetServerSidePropsType<typeof getServerSideProp
 
 	const postsByYear = useMemo(() => groupByYear(sitemapPosts), [sitemapPosts]);
 	const years = Object.keys(postsByYear).sort((a, b) => Number(b) - Number(a));
+	const trimmedSearchQuery = sitemapSearchQuery.trim();
+	const isSearchDisabled = isSearching || trimmedSearchQuery.length === 0;
 
 	const submitSitemapSearch = async (event: FormEvent<HTMLFormElement>) => {
 		event.preventDefault();
-		if (isSearching) return;
+		if (isSearchDisabled) return;
 
-		const query = sitemapSearchQuery.trim();
+		const query = trimmedSearchQuery;
 		setIsSearching(true);
 
 		try {
@@ -266,7 +268,7 @@ function SitemapPage(props: InferGetServerSidePropsType<typeof getServerSideProp
 							/>
 							<button
 								type="submit"
-								disabled={isSearching}
+								disabled={isSearchDisabled}
 								className="inline-flex items-center justify-center gap-2 rounded-full bg-blue-600 px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-300 disabled:cursor-not-allowed disabled:opacity-70 dark:bg-blue-500 dark:hover:bg-blue-400 dark:focus:ring-blue-800"
 							>
 								{isSearching && (

--- a/packages/blog-starter-kit/themes/eplus/pages/sitemap.tsx
+++ b/packages/blog-starter-kit/themes/eplus/pages/sitemap.tsx
@@ -1,9 +1,10 @@
 import request from 'graphql-request';
 import { GetServerSidePropsContext, InferGetServerSidePropsType } from 'next';
+import { NextIntlClientProvider, useTranslations } from 'next-intl';
 import Head from 'next/head';
 import Link from 'next/link';
-import { NextIntlClientProvider } from 'next-intl';
 import { useRouter } from 'next/router';
+import { FormEvent, useMemo, useState } from 'react';
 
 import { AppProvider } from '../components/contexts/appContext';
 import { Header } from '../components/header';
@@ -17,10 +18,12 @@ import {
 	PostsByPublicationQuery,
 	PostsByPublicationQueryVariables,
 } from '../generated/graphql';
-import { replaceLegacyPublicationUrl } from '../utils/urls';
 import { getTimezoneFromLocale } from '../utils/timezone';
+import { replaceLegacyPublicationUrl } from '../utils/urls';
 
 const GQL_ENDPOINT = process.env.NEXT_PUBLIC_HASHNODE_GQL_ENDPOINT;
+const HASHNODE_PUBLICATION_HOST = process.env.NEXT_PUBLIC_HASHNODE_PUBLICATION_HOST;
+const SITEMAP_POSTS_LIMIT = 50;
 
 type SitemapPost = {
 	id: string;
@@ -28,6 +31,11 @@ type SitemapPost = {
 	slug: string;
 	url: string;
 	publishedAt: string;
+};
+
+type SitemapPageInfo = {
+	endCursor?: string | null;
+	hasNextPage?: boolean | null;
 };
 
 type PostsByYear = Record<string, SitemapPost[]>;
@@ -42,24 +50,119 @@ function groupByYear(posts: SitemapPost[]): PostsByYear {
 	return grouped;
 }
 
+function mapPostToSitemapPost(post: {
+	id: string;
+	title: string;
+	slug: string;
+	url: string;
+	publishedAt: string;
+}): SitemapPost {
+	return {
+		id: post.id,
+		title: post.title,
+		slug: post.slug,
+		url: replaceLegacyPublicationUrl(post.url) || post.url,
+		publishedAt: post.publishedAt,
+	};
+}
+
+function sortPostsNewestFirst(posts: SitemapPost[]): SitemapPost[] {
+	return [...posts].sort(
+		(a, b) => new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime(),
+	);
+}
+
+function SitemapPostsSkeleton() {
+	return (
+		<div className="space-y-3" aria-hidden="true">
+			{Array.from({ length: 5 }).map((_, index) => (
+				<div key={index} className="flex animate-pulse items-center gap-3 rounded-lg px-3 py-2.5">
+					<div className="h-3 w-16 shrink-0 rounded-full bg-slate-200 dark:bg-slate-800" />
+					<div className="h-4 flex-1 rounded-full bg-slate-200 dark:bg-slate-800" />
+				</div>
+			))}
+		</div>
+	);
+}
+
 function SitemapPage(props: InferGetServerSidePropsType<typeof getServerSideProps>) {
-	const { publication, posts, totalPosts } = props;
+	const router = useRouter();
+	const t = useTranslations();
+	const { publication, posts, totalPosts, initialPageInfo } = props;
+	const [sitemapPosts, setSitemapPosts] = useState(posts);
+	const [pageInfo, setPageInfo] = useState<SitemapPageInfo>(initialPageInfo);
+	const [isLoadingMore, setIsLoadingMore] = useState(false);
+	const [loadMoreError, setLoadMoreError] = useState<string | null>(null);
+	const [sitemapSearchQuery, setSitemapSearchQuery] = useState('');
+	const [isSearching, setIsSearching] = useState(false);
+	const hasMorePosts = Boolean(pageInfo.hasNextPage);
 	const publicationUrl = replaceLegacyPublicationUrl(publication.url) || publication.url;
 	const pubTitle = publication.displayTitle || publication.title;
 
-	const postsByYear = groupByYear(posts);
+	const postsByYear = useMemo(() => groupByYear(sitemapPosts), [sitemapPosts]);
 	const years = Object.keys(postsByYear).sort((a, b) => Number(b) - Number(a));
+
+	const submitSitemapSearch = async (event: FormEvent<HTMLFormElement>) => {
+		event.preventDefault();
+		if (isSearching) return;
+
+		const query = sitemapSearchQuery.trim();
+		setIsSearching(true);
+
+		try {
+			await router.push({
+				pathname: '/search',
+				query: query ? { q: query } : {},
+			});
+		} catch (error) {
+			console.error('Error while opening sitemap search', error);
+			setIsSearching(false);
+		}
+	};
+
+	const loadMorePosts = async () => {
+		if (!hasMorePosts || isLoadingMore) return;
+
+		setIsLoadingMore(true);
+		setLoadMoreError(null);
+
+		try {
+			const data = await request<MorePostsByPublicationQuery, MorePostsByPublicationQueryVariables>(
+				GQL_ENDPOINT,
+				MorePostsByPublicationDocument,
+				{
+					host: HASHNODE_PUBLICATION_HOST,
+					first: SITEMAP_POSTS_LIMIT,
+					after: pageInfo.endCursor,
+				},
+			);
+
+			const nextPosts =
+				data.publication?.posts.edges.map((edge) => mapPostToSitemapPost(edge.node)) || [];
+			setSitemapPosts((currentPosts) => sortPostsNewestFirst([...currentPosts, ...nextPosts]));
+			setPageInfo(data.publication?.posts.pageInfo || { endCursor: null, hasNextPage: false });
+		} catch (error) {
+			console.error('Error while loading more sitemap posts', error);
+			setLoadMoreError(t('sitemap.loadMoreError'));
+		} finally {
+			setIsLoadingMore(false);
+		}
+	};
 
 	return (
 		<AppProvider publication={publication}>
 			<Layout>
 				<Head>
-					<title>{`Sitemap — ${pubTitle}`}</title>
+					<title>{`${t('sitemap.title')} — ${pubTitle}`}</title>
 					<meta name="robots" content="index, follow" />
 					<link rel="canonical" href={`${publicationUrl}/sitemap`} />
 					<meta
 						name="description"
-						content={`Complete sitemap of all ${totalPosts} articles published on ${pubTitle}.`}
+						content={t('sitemap.metaDescription', {
+							shown: sitemapPosts.length,
+							total: totalPosts,
+							title: pubTitle,
+						})}
 					/>
 				</Head>
 
@@ -68,15 +171,56 @@ function SitemapPage(props: InferGetServerSidePropsType<typeof getServerSideProp
 				<main className="container mx-auto max-w-5xl px-4 py-12 md:px-6">
 					{/* Page header */}
 					<div className="mb-10 border-b pb-8 dark:border-slate-800">
-						<h1 className="mb-3 font-heading text-3xl font-extrabold text-slate-900 dark:text-white md:text-4xl">
-							Sitemap
+						<h1 className="font-heading mb-3 text-3xl font-extrabold text-slate-900 md:text-4xl dark:text-white">
+							{t('sitemap.title')}
 						</h1>
 						<p className="text-slate-500 dark:text-slate-400">
-							{totalPosts} articles published on{' '}
-							<Link href="/" className="font-medium text-blue-600 hover:underline dark:text-blue-400">
-								{pubTitle}
-							</Link>
+							{t.rich('sitemap.showing', {
+								shown: sitemapPosts.length,
+								total: totalPosts,
+								title: pubTitle,
+								publication: (chunks) => (
+									<Link
+										href="/"
+										className="font-medium text-blue-600 hover:underline dark:text-blue-400"
+									>
+										{chunks}
+									</Link>
+								),
+							})}
 						</p>
+						<form
+							onSubmit={submitSitemapSearch}
+							aria-busy={isSearching}
+							className="mt-6 flex flex-col gap-3 rounded-2xl border border-slate-200 bg-slate-50 p-3 sm:flex-row dark:border-slate-800 dark:bg-slate-900/60"
+						>
+							<label className="sr-only" htmlFor="sitemap-search">
+								{t('sitemap.searchLabel')}
+							</label>
+							<input
+								id="sitemap-search"
+								type="search"
+								value={sitemapSearchQuery}
+								onChange={(event) => setSitemapSearchQuery(event.target.value)}
+								placeholder={t('sitemap.searchPlaceholder')}
+								disabled={isSearching}
+								className="min-w-0 flex-1 rounded-full border border-slate-200 bg-white px-4 py-2.5 text-sm text-slate-800 outline-none transition placeholder:text-slate-400 focus:border-blue-400 focus:ring-2 focus:ring-blue-100 disabled:cursor-not-allowed disabled:opacity-70 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:placeholder:text-slate-500 dark:focus:border-blue-500 dark:focus:ring-blue-950"
+							/>
+							<button
+								type="submit"
+								disabled={isSearching}
+								className="inline-flex items-center justify-center gap-2 rounded-full bg-blue-600 px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-300 disabled:cursor-not-allowed disabled:opacity-70 dark:bg-blue-500 dark:hover:bg-blue-400 dark:focus:ring-blue-800"
+							>
+								{isSearching && (
+									<span
+										className="h-4 w-4 animate-spin rounded-full border-2 border-white/40 border-t-white"
+										aria-hidden="true"
+									/>
+								)}
+								{isSearching ? t('sitemap.searching') : t('sitemap.searchButton')}
+							</button>
+						</form>
+
 						<div className="mt-4 flex flex-wrap gap-3 text-sm">
 							<a
 								href="/sitemap/index.xml"
@@ -84,7 +228,12 @@ function SitemapPage(props: InferGetServerSidePropsType<typeof getServerSideProp
 								target="_blank"
 								rel="noopener noreferrer"
 							>
-								<svg className="h-3.5 w-3.5" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+								<svg
+									className="h-3.5 w-3.5"
+									fill="currentColor"
+									viewBox="0 0 20 20"
+									aria-hidden="true"
+								>
 									<path d="M10 12a2 2 0 100-4 2 2 0 000 4z" />
 									<path
 										fillRule="evenodd"
@@ -92,7 +241,7 @@ function SitemapPage(props: InferGetServerSidePropsType<typeof getServerSideProp
 										clipRule="evenodd"
 									/>
 								</svg>
-								XML Sitemap Index
+								{t('sitemap.xmlIndex')}
 							</a>
 							<a
 								href="/sitemap/posts.xml"
@@ -100,7 +249,12 @@ function SitemapPage(props: InferGetServerSidePropsType<typeof getServerSideProp
 								target="_blank"
 								rel="noopener noreferrer"
 							>
-								<svg className="h-3.5 w-3.5" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+								<svg
+									className="h-3.5 w-3.5"
+									fill="currentColor"
+									viewBox="0 0 20 20"
+									aria-hidden="true"
+								>
 									<path
 										fillRule="evenodd"
 										d="M2 5a2 2 0 012-2h8a2 2 0 012 2v10a2 2 0 002 2H4a2 2 0 01-2-2V5zm3 1h6v4H5V6zm6 6H5v2h6v-2z"
@@ -108,7 +262,7 @@ function SitemapPage(props: InferGetServerSidePropsType<typeof getServerSideProp
 									/>
 									<path d="M15 7h1a2 2 0 012 2v5.5a1.5 1.5 0 01-3 0V7z" />
 								</svg>
-								Posts XML
+								{t('sitemap.postsXml')}
 							</a>
 							<a
 								href="/sitemap/tags.xml"
@@ -116,21 +270,25 @@ function SitemapPage(props: InferGetServerSidePropsType<typeof getServerSideProp
 								target="_blank"
 								rel="noopener noreferrer"
 							>
-								<svg className="h-3.5 w-3.5" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+								<svg
+									className="h-3.5 w-3.5"
+									fill="currentColor"
+									viewBox="0 0 20 20"
+									aria-hidden="true"
+								>
 									<path
 										fillRule="evenodd"
 										d="M17.707 9.293a1 1 0 010 1.414l-7 7a1 1 0 01-1.414 0l-7-7A.997.997 0 012 10V5a3 3 0 013-3h5c.256 0 .512.098.707.293l7 7zM5 6a1 1 0 100-2 1 1 0 000 2z"
 										clipRule="evenodd"
 									/>
 								</svg>
-								Tags XML
+								{t('sitemap.tagsXml')}
 							</a>
 						</div>
 					</div>
-
 					{/* Quick year nav */}
 					{years.length > 1 && (
-						<nav className="mb-8 flex flex-wrap gap-2" aria-label="Jump to year">
+						<nav className="mb-8 flex flex-wrap gap-2" aria-label={t('sitemap.jumpToYear')}>
 							{years.map((year) => (
 								<a
 									key={year}
@@ -156,7 +314,11 @@ function SitemapPage(props: InferGetServerSidePropsType<typeof getServerSideProp
 									</h2>
 									<span className="rounded-full bg-slate-100 px-2.5 py-0.5 text-xs font-semibold text-slate-500 dark:bg-slate-800 dark:text-slate-400">
 										{postsByYear[year].length}{' '}
-										{postsByYear[year].length === 1 ? 'article' : 'articles'}
+										{t(
+											postsByYear[year].length === 1
+												? 'sitemap.articleSingular'
+												: 'sitemap.articlePlural',
+										)}
 									</span>
 									<div className="h-px flex-1 bg-slate-100 dark:bg-slate-800" aria-hidden="true" />
 								</div>
@@ -189,9 +351,30 @@ function SitemapPage(props: InferGetServerSidePropsType<typeof getServerSideProp
 						))}
 					</div>
 
-					{posts.length === 0 && (
+					{isLoadingMore && <SitemapPostsSkeleton />}
+
+					{loadMoreError && (
+						<p className="mt-6 text-center text-sm text-red-600 dark:text-red-400">
+							{loadMoreError}
+						</p>
+					)}
+
+					{hasMorePosts && (
+						<div className="mt-10 flex justify-center">
+							<button
+								type="button"
+								onClick={loadMorePosts}
+								disabled={isLoadingMore}
+								className="rounded-full bg-slate-900 px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-slate-700 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-white dark:text-slate-900 dark:hover:bg-slate-200"
+							>
+								{isLoadingMore ? t('sitemap.loadingPosts') : t('sitemap.loadMorePosts')}
+							</button>
+						</div>
+					)}
+
+					{sitemapPosts.length === 0 && (
 						<p className="py-16 text-center text-slate-500 dark:text-slate-400">
-							No articles found.
+							{t('sitemap.noArticlesFound')}
 						</p>
 					)}
 				</main>
@@ -209,7 +392,9 @@ function SitemapPage(props: InferGetServerSidePropsType<typeof getServerSideProp
 	);
 }
 
-export default function SitemapPageWrapper(props: InferGetServerSidePropsType<typeof getServerSideProps>) {
+export default function SitemapPageWrapper(
+	props: InferGetServerSidePropsType<typeof getServerSideProps>,
+) {
 	const router = useRouter();
 	return (
 		<NextIntlClientProvider
@@ -232,8 +417,8 @@ export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
 		GQL_ENDPOINT,
 		PostsByPublicationDocument,
 		{
-			host: process.env.NEXT_PUBLIC_HASHNODE_PUBLICATION_HOST,
-			first: 50,
+			host: HASHNODE_PUBLICATION_HOST,
+			first: SITEMAP_POSTS_LIMIT,
 		},
 	);
 
@@ -242,53 +427,18 @@ export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
 		return { notFound: true };
 	}
 
-	// Collect all posts via pagination
-	const posts: SitemapPost[] = publication.posts.edges.map((edge) => ({
-		id: edge.node.id,
-		title: edge.node.title,
-		slug: edge.node.slug,
-		url: replaceLegacyPublicationUrl(edge.node.url) || edge.node.url,
-		publishedAt: edge.node.publishedAt,
-	}));
-
-	const fetchMore = async (after: string | null | undefined): Promise<void> => {
-		const data = await request<MorePostsByPublicationQuery, MorePostsByPublicationQueryVariables>(
-			GQL_ENDPOINT,
-			MorePostsByPublicationDocument,
-			{
-				host: process.env.NEXT_PUBLIC_HASHNODE_PUBLICATION_HOST,
-				first: 50,
-				after,
-			},
-		);
-		if (!data.publication) return;
-		for (const edge of data.publication.posts.edges) {
-			posts.push({
-				id: edge.node.id,
-				title: edge.node.title,
-				slug: edge.node.slug,
-				url: replaceLegacyPublicationUrl(edge.node.url) || edge.node.url,
-				publishedAt: edge.node.publishedAt,
-			});
-		}
-		if (data.publication.posts.pageInfo.hasNextPage) {
-			await fetchMore(data.publication.posts.pageInfo.endCursor);
-		}
-	};
-
-	if (publication.posts.pageInfo.hasNextPage) {
-		await fetchMore(publication.posts.pageInfo.endCursor);
-	}
-
-	// Sort newest first
-	posts.sort((a, b) => new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime());
+	// Load only the first page of posts so the HTML sitemap can render quickly.
+	const posts = sortPostsNewestFirst(
+		publication.posts.edges.map((edge) => mapPostToSitemapPost(edge.node)),
+	);
 
 	return {
 		props: {
 			messages,
 			publication,
 			posts,
-			totalPosts: posts.length,
+			totalPosts: publication.posts.totalDocuments ?? posts.length,
+			initialPageInfo: publication.posts.pageInfo,
 		},
 	};
 };

--- a/packages/blog-starter-kit/themes/eplus/pages/sitemap.tsx
+++ b/packages/blog-starter-kit/themes/eplus/pages/sitemap.tsx
@@ -98,6 +98,16 @@ function SitemapPage(props: InferGetServerSidePropsType<typeof getServerSideProp
 	const hasMorePosts = Boolean(pageInfo.hasNextPage);
 	const publicationUrl = replaceLegacyPublicationUrl(publication.url) || publication.url;
 	const pubTitle = publication.displayTitle || publication.title;
+	const activeLocale = router.locale ?? 'en';
+	const sitemapDateFormatter = useMemo(
+		() =>
+			new Intl.DateTimeFormat(activeLocale, {
+				day: '2-digit',
+				month: 'short',
+				timeZone: getTimezoneFromLocale(activeLocale),
+			}),
+		[activeLocale],
+	);
 
 	const postsByYear = useMemo(() => groupByYear(sitemapPosts), [sitemapPosts]);
 	const years = Object.keys(postsByYear).sort((a, b) => Number(b) - Number(a));
@@ -325,8 +335,7 @@ function SitemapPage(props: InferGetServerSidePropsType<typeof getServerSideProp
 								<ul className="space-y-1">
 									{postsByYear[year].map((post) => {
 										const date = new Date(post.publishedAt);
-										const month = date.toLocaleString('en', { month: 'short' });
-										const day = String(date.getDate()).padStart(2, '0');
+										const formattedDate = sitemapDateFormatter.format(date);
 										return (
 											<li key={post.id}>
 												<Link
@@ -337,7 +346,7 @@ function SitemapPage(props: InferGetServerSidePropsType<typeof getServerSideProp
 														dateTime={post.publishedAt}
 														className="mt-0.5 w-16 shrink-0 text-xs font-medium tabular-nums text-slate-400 dark:text-slate-500"
 													>
-														{month} {day}
+														{formattedDate}
 													</time>
 													<span className="leading-snug text-slate-700 group-hover:text-blue-600 dark:text-slate-300 dark:group-hover:text-blue-400">
 														{post.title}


### PR DESCRIPTION
### Motivation

- Provide a localized, interactive sitemap UI with search and progressive loading so the sitemap page renders fast and supports multiple locales.
- Avoid fetching all posts on the server to improve SSR performance while enabling clients to load more posts on demand.

### Description

- Added localized `sitemap` message keys to theme message files (`en.json`, `es.json`, `fr.json`, `hi.json`, `ja.json`, `vi.json`, `zh.json`).
- Reworked `pages/sitemap.tsx` to use `next-intl` (`NextIntlClientProvider` and `useTranslations`) and replace hard-coded strings with translation lookups.
- Implemented client-side search form that navigates to the `/search` page, incremental `loadMorePosts` using `graphql-request` and `MorePostsByPublicationDocument`, and associated loading/error UI and a skeleton placeholder component.
- Introduced helper functions `mapPostToSitemapPost`, `sortPostsNewestFirst`, `groupByYear`, constants `SITEMAP_POSTS_LIMIT` and `HASHNODE_PUBLICATION_HOST`, and switched server-side props to return only the first page of posts plus `initialPageInfo` (and `totalPosts` from `publication.posts.totalDocuments`).

### Testing

- Type-check: ran `tsc --noEmit` (TypeScript) and it succeeded.
- Build: ran `next build` locally and the application compiled successfully without runtime build errors.
- No new automated unit tests were added for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe84781d288328bb0731c7a6be6d9d)